### PR TITLE
Fixing loading spinner behavior in cards

### DIFF
--- a/app_feup/android/local.properties
+++ b/app_feup/android/local.properties
@@ -1,5 +1,5 @@
-sdk.dir=/Users/nunolopes/Library/Android/sdk
-flutter.sdk=/Users/nunolopes/Documents/flutter
+sdk.dir=/home/reeckset/Android/Sdk
+flutter.sdk=/home/reeckset/flutter
 flutter.buildMode=debug
 flutter.versionName=1.0.0
 flutter.versionCode=1

--- a/app_feup/lib/controller/LoadInfo.dart
+++ b/app_feup/lib/controller/LoadInfo.dart
@@ -47,8 +47,6 @@ void loadLocalUserInfoToState(store) async {
     store.dispatch(SetPrintBalanceStatusAction(RequestStatus.SUCCESSFUL));
     store.dispatch(SetFeesStatusAction(RequestStatus.SUCCESSFUL));
     store.dispatch(SetCoursesStatesStatusAction(RequestStatus.SUCCESSFUL));
-    store.dispatch(SetScheduleStatusAction(RequestStatus.SUCCESSFUL));
-    store.dispatch(SetExamsStatusAction(RequestStatus.SUCCESSFUL));
   }
 }
 

--- a/app_feup/lib/redux/ActionCreators.dart
+++ b/app_feup/lib/redux/ActionCreators.dart
@@ -52,10 +52,10 @@ ThunkAction<AppState> login(username, password, faculty, persistentSession) {
           username, password, faculty, persistentSession);
       store.dispatch(new SaveLoginDataAction(session));
       if (session.authenticated) {
+        store.dispatch(new SetLoginStatusAction(RequestStatus.SUCCESSFUL));
         if (persistentSession)
           AppSharedPreferences.savePersistentUserInfo(username, password);
         await loadUserInfoToState(store);
-        store.dispatch(new SetLoginStatusAction(RequestStatus.SUCCESSFUL));
       } else {
         store.dispatch(new SetLoginStatusAction(RequestStatus.FAILED));
       }

--- a/app_feup/lib/view/Widgets/ExamCard.dart
+++ b/app_feup/lib/view/Widgets/ExamCard.dart
@@ -25,35 +25,25 @@ class ExamCard extends GenericCard{
   Widget buildCardContent(BuildContext context) {
     return StoreConnector<AppState, List<dynamic>>(
       converter: (store) => store.state.content['exams'],
-      builder: (context, exams) => getCardContent(context, exams)
+      builder: (context, exams) =>
+          super.getCardContentBasedOnRequestStatus(
+              context,
+              StoreProvider.of<AppState>(context).state.content['examsStatus'],
+              generateExams,
+              exams,
+              exams != null && exams.length > 0)
     );
   }
 
-  Widget getCardContent(BuildContext context, exams){
-    switch (StoreProvider.of<AppState>(context).state.content['examsStatus']){
-      case RequestStatus.SUCCESSFUL:
-        return exams.length >= 1 ?
-          new Column(
-                mainAxisSize: MainAxisSize.min,
-                children: this.getExamRows(context, exams),
-              )
-          : Center(
-            child: Text("No exams to show at the moment", style: Theme.of(context).textTheme.display1),
-          );
-      case RequestStatus.BUSY:
-        return Center(child: CircularProgressIndicator());
-        break;
-      case RequestStatus.FAILED:
-        if(exams.length != 0)
-          return new Column(
-                mainAxisSize: MainAxisSize.min,
-                children: this.getExamRows(context, exams),
-            );
-        else return Center(child: Text("Comunication error. Please check your internet connection.", style: Theme.of(context).textTheme.display1));
-        break;
-      default:
-        return Container();
-    }
+  Widget generateExams(exams, context){
+    return exams.length >= 1 ?
+    new Column(
+      mainAxisSize: MainAxisSize.min,
+      children: this.getExamRows(context, exams),
+    )
+        : Center(
+      child: Text("No exams to show at the moment", style: Theme.of(context).textTheme.display1),
+    );
   }
 
   List<Widget> getExamRows(context, exams){

--- a/app_feup/lib/view/Widgets/GenericCard.dart
+++ b/app_feup/lib/view/Widgets/GenericCard.dart
@@ -1,3 +1,4 @@
+import 'package:app_feup/model/AppState.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
@@ -41,6 +42,29 @@ abstract class GenericCard extends StatefulWidget {
                 t.minute.toString(),
             style: Theme.of(context).textTheme.display3),
         alignment: Alignment.center);
+  }
+
+
+  Widget getCardContentBasedOnRequestStatus(BuildContext context, RequestStatus status, Function contentGenerator, content, bool contentChecker) {
+    switch (status) {
+      case RequestStatus.SUCCESSFUL:
+        return contentGenerator(content, context);
+      case RequestStatus.BUSY:
+        return contentChecker ?
+        contentGenerator(content, context)
+            : Center(child: CircularProgressIndicator());
+      case RequestStatus.FAILED:
+        return contentChecker ?
+        contentGenerator(content, context)
+            : Center(child: Text(
+            "Comunication error. Please check your internet connection.",
+            style: Theme
+                .of(context)
+                .textTheme
+                .display1));
+      default:
+        return Container();
+    }
   }
 }
 

--- a/app_feup/lib/view/Widgets/ScheduleCard.dart
+++ b/app_feup/lib/view/Widgets/ScheduleCard.dart
@@ -20,24 +20,24 @@ class ScheduleCard extends GenericCard {
   Widget buildCardContent(BuildContext context) {
     return StoreConnector<AppState, List<dynamic>>(
         converter: (store) => store.state.content['schedule'],
-        builder: (context, lectures) => getCardContent(context, lectures)
+        builder: (context, lectures) =>
+          super.getCardContentBasedOnRequestStatus(
+              context,
+              StoreProvider.of<AppState>(context).state.content['scheduleStatus'],
+              generateSchedule,
+              lectures,
+              lectures != null && lectures.length > 0)
     );
   }
 
   Widget getCardContent(BuildContext context, lectures){
     switch (StoreProvider.of<AppState>(context).state.content['scheduleStatus']){
       case RequestStatus.SUCCESSFUL:
-        return lectures.length >= 1 ?
-        Container(
-            child: new Column(
-              mainAxisSize: MainAxisSize.min,
-              children: getScheduleRows(context, lectures),
-            ))
-            : Center(
-            child: Text("No lectures or classes to show at the moment", style: Theme.of(context).textTheme.display1, textAlign: TextAlign.center)
-        );
+        return generateSchedule(lectures, context);
       case RequestStatus.BUSY:
-        return Center(child: CircularProgressIndicator());
+        return (lectures != null && lectures.length > 0) ?
+        generateSchedule(lectures, context) :
+        Center(child: CircularProgressIndicator());
       case RequestStatus.FAILED:
         if(lectures.length != 0)
           return Container(
@@ -51,6 +51,18 @@ class ScheduleCard extends GenericCard {
       default:
         return Container();
     }
+  }
+
+  Widget generateSchedule(lectures, context){
+    return lectures.length >= 1 ?
+    Container(
+        child: new Column(
+          mainAxisSize: MainAxisSize.min,
+          children: getScheduleRows(context, lectures),
+        ))
+        : Center(
+        child: Text("No lectures or classes to show at the moment", style: Theme.of(context).textTheme.display1, textAlign: TextAlign.center)
+    );
   }
 
   List<Widget> getScheduleRows(context, List<Lecture> lectures){

--- a/app_feup/lib/view/Widgets/ScheduleCard.dart
+++ b/app_feup/lib/view/Widgets/ScheduleCard.dart
@@ -20,37 +20,18 @@ class ScheduleCard extends GenericCard {
   Widget buildCardContent(BuildContext context) {
     return StoreConnector<AppState, List<dynamic>>(
         converter: (store) => store.state.content['schedule'],
-        builder: (context, lectures) =>
-          super.getCardContentBasedOnRequestStatus(
+        builder: (context, lectures) {
+          return super.getCardContentBasedOnRequestStatus(
               context,
-              StoreProvider.of<AppState>(context).state.content['scheduleStatus'],
+              StoreProvider
+                  .of<AppState>(context)
+                  .state
+                  .content['scheduleStatus'],
               generateSchedule,
               lectures,
-              lectures != null && lectures.length > 0)
+              lectures != null && lectures.length > 0);
+        }
     );
-  }
-
-  Widget getCardContent(BuildContext context, lectures){
-    switch (StoreProvider.of<AppState>(context).state.content['scheduleStatus']){
-      case RequestStatus.SUCCESSFUL:
-        return generateSchedule(lectures, context);
-      case RequestStatus.BUSY:
-        return (lectures != null && lectures.length > 0) ?
-        generateSchedule(lectures, context) :
-        Center(child: CircularProgressIndicator());
-      case RequestStatus.FAILED:
-        if(lectures.length != 0)
-          return Container(
-              child: new Column(
-                mainAxisSize: MainAxisSize.min,
-                children: getScheduleRows(context, lectures),
-              )
-          );
-        else return Center(child: Text("Comunication error. Please check your internet connection."));
-        break;
-      default:
-        return Container();
-    }
   }
 
   Widget generateSchedule(lectures, context){


### PR DESCRIPTION
The loading spinner should not appear if the information is already available locally

Fixes #146 