### PR TITLE
Fixed profile concurrency on first persistent login

### DIFF
--- a/app_feup/lib/redux/ActionCreators.dart
+++ b/app_feup/lib/redux/ActionCreators.dart
@@ -56,9 +56,9 @@ ThunkAction<AppState> login(username, password, faculty, persistentSession) {
       store.dispatch(new SaveLoginDataAction(session));
       if (session.authenticated) {
         store.dispatch(new SetLoginStatusAction(RequestStatus.SUCCESSFUL));
+        await loadUserInfoToState(store);
         if (persistentSession)
           AppSharedPreferences.savePersistentUserInfo(username, password);
-        await loadUserInfoToState(store);
       } else {
         store.dispatch(new SetLoginStatusAction(RequestStatus.FAILED));
       }


### PR DESCRIPTION
When logging in for the first time and checking the persistent login box, it was trying to load the locally stored information, even though it did not exist. This leaded to a null userInfo and, consequently, empty exams and an error in the profile page.