### PR TITLE
Fixed small splash screen on certain screens

### DIFF
--- a/app_feup/android/app/src/main/res/drawable/launch_background.xml
+++ b/app_feup/android/app/src/main/res/drawable/launch_background.xml
@@ -7,6 +7,6 @@
        </shape>
     </item>
     <item>
-        <bitmap android:gravity="center" android:src="@drawable/splash" />
+        <bitmap android:gravity="fill" android:src="@drawable/splash" />
     </item>
 </layer-list>

--- a/app_feup/android/app/src/main/res/values/styles.xml
+++ b/app_feup/android/app/src/main/res/values/styles.xml
@@ -4,7 +4,5 @@
         <!-- Show a splash screen on the activity. Automatically removed when
              Flutter draws its first frame -->
         <item name="android:windowBackground">@drawable/launch_background</item>
-        <item name="android:windowFullscreen">true</item>
-
     </style>
 </resources>


### PR DESCRIPTION
It also fixes the fullscreen option given to the splash screen which was also causing the content to be in fullscreen.

This is what the splash screen looked like on a device.

![image](https://user-images.githubusercontent.com/26902818/75405093-7ec80380-5904-11ea-8115-1f858fbb9539.png)
