### PR TITLE
Fixed repeated animation in the main page

### DIFF
--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -89,7 +89,12 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
           materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
           shape: RoundedRectangleBorder(),
           child: TextButton(
-            onPressed: () => Navigator.pushNamed(context, '/' + Constants.navPersonalArea),
+            onPressed: () {
+              final currentRouteName = ModalRoute.of(context).settings.name;
+              if(currentRouteName != Constants.navPersonalArea){
+                Navigator.pushNamed(context, '/${Constants.navPersonalArea}');
+              }
+            },
             child: SvgPicture.asset(
               'assets/images/logo_dark.svg',
               height: queryData.size.height / 25,


### PR DESCRIPTION
Closes #207 
Added a condition in buildAppBar function of GeneralPageView so that, when pressing the NI logo, only a new context is pushed to the navigator if the current page is not the main page.