### PR TITLE
Empty bus stop list

### DIFF
--- a/app_feup/lib/view/Widgets/bus_stop_search.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_search.dart
@@ -148,7 +148,6 @@ class BusStopSearch extends SearchDelegate<String> {
   }
 
   Future<List<String>> getStops() async {
-    print("QUERY LOOKING: " + query + '\n');
     if (query != '') {
       return NetworkRouter.getStopsByName(query);
     }

--- a/app_feup/lib/view/Widgets/bus_stop_search.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_search.dart
@@ -49,7 +49,7 @@ class BusStopSearch extends SearchDelegate<String> {
 
   @override
   Widget buildResults(BuildContext context) {
-    return Container();
+    return getSuggestionList(context);
   }
 
   void updateStopCallback(String stopCode, BusStopData stopData) {
@@ -148,6 +148,7 @@ class BusStopSearch extends SearchDelegate<String> {
   }
 
   Future<List<String>> getStops() async {
+    print("QUERY LOOKING: " + query + '\n');
     if (query != '') {
       return NetworkRouter.getStopsByName(query);
     }

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.0.0+12
+version: 1.0.0+13
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #239

Very simple fix, building results for a certain query was returning an empty container when closing the search bar, now returns the suggestion list using the value of 'query'.