### PR TITLE
fix(exams): 🐛 sort exams by date

### DIFF
--- a/app_feup/lib/redux/action_creators.dart
+++ b/app_feup/lib/redux/action_creators.dart
@@ -221,9 +221,7 @@ ThunkAction<AppState> getUserExams(Completer<Null> action,
 
       final List<Exam> exams = await extractExams(store, parserExams);
       
-      exams.sort((exam1, exam2) {
-        return exam1.date.compareTo(exam2.date);
-      });
+      exams.sort((exam1, exam2) => exam1.date.compareTo(exam2.date));
 
       // Updates local database according to the information fetched -- Exams
       if (userPersistentInfo.item1 != '' && userPersistentInfo.item2 != '') {

--- a/app_feup/lib/redux/action_creators.dart
+++ b/app_feup/lib/redux/action_creators.dart
@@ -220,6 +220,10 @@ ThunkAction<AppState> getUserExams(Completer<Null> action,
       store.dispatch(SetExamsStatusAction(RequestStatus.busy));
 
       final List<Exam> exams = await extractExams(store, parserExams);
+      
+      exams.sort((exam1, exam2) {
+        return exam1.date.compareTo(exam2.date);
+      });
 
       // Updates local database according to the information fetched -- Exams
       if (userPersistentInfo.item1 != '' && userPersistentInfo.item2 != '') {

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.0.0+4
+version: 1.0.0+5
 
 environment:
   sdk: ">=2.2.0 <3.0.0"


### PR DESCRIPTION
Before the changes in this pull request were made, the exam entries would be sorted by exam type (I think). Now, with these changes, the exam entries in the exams page will be ordered by date.

The places where the exams need sorting are:
1. When the exams are scraped from the web (since this triggers an UI update).
2. ~~When the database is queried. In this case, I still called sort() in the code, instead of using sortBy in the database query, because it is easier to do it this way. Nonetheless, I am open to discussion on what is the best solution for this case.~~

**Before**
![image](https://user-images.githubusercontent.com/13498603/103713222-b3d8c400-4fb3-11eb-8f06-13753e78039a.png)

**After**
![image](https://user-images.githubusercontent.com/13498603/103713240-be935900-4fb3-11eb-82e5-6d0d60ca6d78.png)

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
