### PR TITLE
Add email form at bug report page

### DIFF
--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -131,8 +131,8 @@ class BugReportFormState extends State<BugReportForm> {
               bottom: BorderSide(color: Theme.of(context).dividerColor))),
       padding: EdgeInsets.only(bottom: 20),
       child: Center(
-        child: Text('''Encontraste algum Bug na aplicação?\nTens alguma
-             sugestão para a app?\nConta-nos para que nós possamos melhorar!''',
+        child: Text(
+            '''Encontraste algum bug na aplicação?\nTens alguma sugestão para a app?\nConta-nos para que nós possamos melhorar!''',
             style: Theme.of(context).textTheme.body1,
             textAlign: TextAlign.center),
       ),

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -300,6 +300,7 @@ class BugReportFormState extends State<BugReportForm> {
 
     setState(() {
       _selectedBug = 0;
+      _isConsentGiven = false;
     });
   }
 

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -296,6 +296,7 @@ class BugReportFormState extends State<BugReportForm> {
   void clearForm() {
     titleController.clear();
     descriptionController.clear();
+    emailController.clear();
 
     setState(() {
       _selectedBug = 0;

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -216,7 +216,9 @@ class BugReportFormState extends State<BugReportForm> {
           ? null
           : () {
               if (_formKey.currentState.validate() && !_isButtonTapped) {
-                FocusScope.of(context).unfocus();
+                if (!FocusScope.of(context).hasPrimaryFocus) {
+                  FocusScope.of(context).unfocus();
+                }
                 submitBugReport();
               }
             },

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -187,7 +187,7 @@ class BugReportFormState extends State<BugReportForm> {
         child: CheckboxListTile(
           activeColor: Theme.of(context).primaryColor,
           title: Text(
-              '''Consinto que a informação seja publicada no GitHub, incluindo o meu contacto pessoal, se fornecido.''',
+              '''Consinto que toda esta informação seja disponibilizada publicamente na plataforma GitHub, incluindo o meu contacto pessoal, se fornecido''',
               style: Theme.of(context).textTheme.body1,
               textAlign: TextAlign.left),
           value: _isConsentGiven,

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -98,6 +98,8 @@ class BugReportFormState extends State<BugReportForm> {
       labelText: 'Email em que desejas ser contactado',
       bottomMargin: 30.0,
       isOptional: true,
+      emptyText: 'Por favor coloca um email válido',
+      validatorType: FormTextFieldValidator.email,
     ));
 
     formWidget.add(consentBox(context));
@@ -135,7 +137,7 @@ class BugReportFormState extends State<BugReportForm> {
       padding: EdgeInsets.only(bottom: 20),
       child: Center(
         child: Text(
-            '''Encontraste algum bug na aplicação?\nTens alguma sugestão para a app?\nConta-nos para que nós possamos melhorar!''',
+            '''Encontraste algum bug na aplicação?\nTens alguma sugestão para a app?\nConta-nos para que possamos melhorar!''',
             style: Theme.of(context).textTheme.body1,
             textAlign: TextAlign.center),
       ),
@@ -149,7 +151,7 @@ class BugReportFormState extends State<BugReportForm> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
           Text(
-            'Seleciona o tipo de ocorrência',
+            'Tipo de ocorrência',
             style: Theme.of(context).textTheme.body1,
             textAlign: TextAlign.left,
           ),
@@ -187,7 +189,7 @@ class BugReportFormState extends State<BugReportForm> {
         child: CheckboxListTile(
           activeColor: Theme.of(context).primaryColor,
           title: Text(
-              '''Consinto que toda esta informação seja disponibilizada publicamente na plataforma GitHub, incluindo o meu contacto pessoal, se fornecido''',
+              '''Consinto que toda esta informação seja disponibilizada publicamente na plataforma GitHub, incluindo o meu contacto pessoal, se fornecido.''',
               style: Theme.of(context).textTheme.body1,
               textAlign: TextAlign.left),
           value: _isConsentGiven,
@@ -218,7 +220,6 @@ class BugReportFormState extends State<BugReportForm> {
         style: TextStyle(color: Colors.white, fontSize: 20.0),
       ),
       disabledColor: Theme.of(context).disabledColor,
-      disabledElevation: 1,
       color: Theme.of(context).primaryColor,
     ));
   }
@@ -286,7 +287,7 @@ class BugReportFormState extends State<BugReportForm> {
       msg,
       context,
       duration: Toast.LENGTH_LONG,
-      gravity: Toast.BOTTOM,
+      gravity: Toast.TOP,
       backgroundColor: theme.toastColor,
       backgroundRadius: 16.0,
       textColor: Colors.white,

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -211,7 +211,7 @@ class BugReportFormState extends State<BugReportForm> {
           if (_isConsentGiven) {
             submitBugReport();
           } else {
-            displayErrorToast('Aceite as condições primeiro!');
+            displayErrorToast('Aceita as condições primeiro!');
           }
         }
       },

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -43,6 +43,7 @@ class BugReportFormState extends State<BugReportForm> {
   String ghToken = '';
 
   bool _isButtonTapped = false;
+  bool _isConsentGiven = false;
 
   BugReportFormState() {
     if (ghToken == '') loadGHKey();
@@ -95,9 +96,11 @@ class BugReportFormState extends State<BugReportForm> {
       maxLines: 2,
       description: 'Contacto (opcional)',
       labelText: 'Email em que desejas ser contactado',
-      hintText: 'Informação pública na página do GitHub!',
       bottomMargin: 30.0,
+      isOptional: true,
     ));
+
+    formWidget.add(consentBox(context));
 
     formWidget.add(submitButton(context));
 
@@ -175,13 +178,41 @@ class BugReportFormState extends State<BugReportForm> {
     );
   }
 
+  Widget consentBox(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.only(),
+      margin: EdgeInsets.only(bottom: 20, top: 0),
+      child: ListTileTheme(
+        contentPadding: EdgeInsets.all(0),
+        child: CheckboxListTile(
+          activeColor: Theme.of(context).primaryColor,
+          title: Text(
+              '''Consinto que a informação seja publicada no GitHub, incluindo o meu contacto pessoal, se fornecido.''',
+              style: Theme.of(context).textTheme.body1,
+              textAlign: TextAlign.left),
+          value: _isConsentGiven,
+          onChanged: (bool newValue) {
+            setState(() {
+              _isConsentGiven = newValue;
+            });
+          },
+          controlAffinity: ListTileControlAffinity.leading,
+        ),
+      ),
+    );
+  }
+
   Widget submitButton(BuildContext context) {
     return Container(
         child: RaisedButton(
       padding: EdgeInsets.symmetric(vertical: 10.0),
       onPressed: () {
         if (_formKey.currentState.validate() && !_isButtonTapped) {
-          submitBugReport();
+          if (_isConsentGiven) {
+            submitBugReport();
+          } else {
+            displayErrorToast('Aceite as condições primeiro!');
+          }
         }
       },
       child: Text(
@@ -233,7 +264,7 @@ class BugReportFormState extends State<BugReportForm> {
       }
 
       FocusScope.of(context).requestFocus(FocusNode());
-      displayBugToast(msg);
+      displayErrorToast(msg);
       setState(() {
         _isButtonTapped = false;
       });
@@ -243,14 +274,14 @@ class BugReportFormState extends State<BugReportForm> {
 
       final String msg =
           (error is SocketException) ? 'Falha de rede' : 'Ocorreu um erro';
-      displayBugToast(msg);
+      displayErrorToast(msg);
       setState(() {
         _isButtonTapped = false;
       });
     });
   }
 
-  void displayBugToast(String msg) {
+  void displayErrorToast(String msg) {
     Toast.show(
       msg,
       context,

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -206,19 +206,19 @@ class BugReportFormState extends State<BugReportForm> {
     return Container(
         child: RaisedButton(
       padding: EdgeInsets.symmetric(vertical: 10.0),
-      onPressed: () {
-        if (_formKey.currentState.validate() && !_isButtonTapped) {
-          if (_isConsentGiven) {
-            submitBugReport();
-          } else {
-            displayErrorToast('Aceita as condições primeiro!');
-          }
-        }
-      },
+      onPressed: !_isConsentGiven
+          ? null
+          : () {
+              if (_formKey.currentState.validate() && !_isButtonTapped) {
+                submitBugReport();
+              }
+            },
       child: Text(
         'Enviar',
         style: TextStyle(color: Colors.white, fontSize: 20.0),
       ),
+      disabledColor: Theme.of(context).disabledColor,
+      disabledElevation: 1,
       color: Theme.of(context).primaryColor,
     ));
   }

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -14,7 +14,7 @@ import 'package:flutter/services.dart' show rootBundle;
 class BugReportForm extends StatefulWidget {
   @override
   State<StatefulWidget> createState() {
-    return  BugReportFormState();
+    return BugReportFormState();
   }
 }
 
@@ -36,11 +36,10 @@ class BugReportFormState extends State<BugReportForm> {
   List<DropdownMenuItem<int>> bugList = [];
 
   static int _selectedBug = 0;
-  static final TextEditingController titleController =
-       TextEditingController();
+  static final TextEditingController titleController = TextEditingController();
   static final TextEditingController descriptionController =
-       TextEditingController();
-
+      TextEditingController();
+  static final TextEditingController emailController = TextEditingController();
   String ghToken = '';
 
   bool _isButtonTapped = false;
@@ -53,25 +52,23 @@ class BugReportFormState extends State<BugReportForm> {
   void loadBugClassList() {
     bugList = [];
 
-    bugDescriptions.forEach((int key, Tuple2<String, String> tup) => {
-          bugList
-              .add( DropdownMenuItem(child:  Text(tup.item1), value: key))
-        });
+    bugDescriptions.forEach((int key, Tuple2<String, String> tup) =>
+        {bugList.add(DropdownMenuItem(child: Text(tup.item1), value: key))});
   }
 
   @override
   Widget build(BuildContext context) {
-    return  Form(
-        key: _formKey, child:  ListView(children: getFormWidget(context)));
+    return Form(
+        key: _formKey, child: ListView(children: getFormWidget(context)));
   }
 
   List<Widget> getFormWidget(BuildContext context) {
-    final List<Widget> formWidget =  List();
+    final List<Widget> formWidget = List();
 
     formWidget.add(bugReportTitle(context));
     formWidget.add(bugReportIntro(context));
     formWidget.add(dropdownBugSelectWidget(context));
-    formWidget.add( FormTextField(
+    formWidget.add(FormTextField(
       titleController,
       Icons.title,
       minLines: 1,
@@ -81,7 +78,7 @@ class BugReportFormState extends State<BugReportForm> {
       bottomMargin: 30.0,
     ));
 
-    formWidget.add( FormTextField(
+    formWidget.add(FormTextField(
       descriptionController,
       Icons.description,
       minLines: 1,
@@ -91,16 +88,27 @@ class BugReportFormState extends State<BugReportForm> {
       bottomMargin: 30.0,
     ));
 
+    formWidget.add(FormTextField(
+      emailController,
+      Icons.mail,
+      minLines: 1,
+      maxLines: 2,
+      description: 'Contacto (opcional)',
+      labelText: 'Email em que desejas ser contactado',
+      hintText: 'Informação pública na página do GitHub!',
+      bottomMargin: 30.0,
+    ));
+
     formWidget.add(submitButton(context));
 
     return formWidget;
   }
 
   Widget bugReportTitle(BuildContext context) {
-    return  Container(
+    return Container(
         alignment: Alignment.center,
-        margin:  EdgeInsets.symmetric(vertical: 10.0, horizontal: 20),
-        child:  Row(
+        margin: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20),
+        child: Row(
           children: <Widget>[
             Icon(Icons.bug_report,
                 color: Theme.of(context).primaryColor, size: 50.0),
@@ -117,14 +125,13 @@ class BugReportFormState extends State<BugReportForm> {
   }
 
   Widget bugReportIntro(BuildContext context) {
-    return  Container(
+    return Container(
       decoration: BoxDecoration(
           border: Border(
               bottom: BorderSide(color: Theme.of(context).dividerColor))),
-      padding:  EdgeInsets.only(bottom: 20),
-      child:  Center(
-        child: Text(
-            '''Encontraste algum Bug na aplicação?\nTens alguma
+      padding: EdgeInsets.only(bottom: 20),
+      child: Center(
+        child: Text('''Encontraste algum Bug na aplicação?\nTens alguma
              sugestão para a app?\nConta-nos para que nós possamos melhorar!''',
             style: Theme.of(context).textTheme.body1,
             textAlign: TextAlign.center),
@@ -133,26 +140,26 @@ class BugReportFormState extends State<BugReportForm> {
   }
 
   Widget dropdownBugSelectWidget(BuildContext context) {
-    return  Container(
+    return Container(
       margin: EdgeInsets.only(bottom: 30, top: 20),
-      child:  Column(
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-           Text(
+          Text(
             'Seleciona o tipo de ocorrência',
             style: Theme.of(context).textTheme.body1,
             textAlign: TextAlign.left,
           ),
-           Row(children: <Widget>[
-             Container(
-                margin:  EdgeInsets.only(right: 15),
-                child:  Icon(
+          Row(children: <Widget>[
+            Container(
+                margin: EdgeInsets.only(right: 15),
+                child: Icon(
                   Icons.bug_report,
                   color: Theme.of(context).primaryColor,
                 )),
             Expanded(
-                child:  DropdownButton(
-              hint:  Text('Seleciona o tipo de ocorrência'),
+                child: DropdownButton(
+              hint: Text('Seleciona o tipo de ocorrência'),
               items: bugList,
               value: _selectedBug,
               onChanged: (value) {
@@ -169,7 +176,7 @@ class BugReportFormState extends State<BugReportForm> {
   }
 
   Widget submitButton(BuildContext context) {
-    return  Container(
+    return Container(
         child: RaisedButton(
       padding: EdgeInsets.symmetric(vertical: 10.0),
       onPressed: () {
@@ -193,10 +200,13 @@ class BugReportFormState extends State<BugReportForm> {
     final String bugLabel = bugDescriptions[_selectedBug] == null
         ? 'Unidentified bug'
         : bugDescriptions[_selectedBug].item2;
+    final String description = emailController.text == ''
+        ? descriptionController.text
+        : descriptionController.text + '\nContact: ' + emailController.text;
     final Map data = {
       'title': titleController.text,
-      'body': descriptionController.text,
-      'labels': [_issueLabel, bugLabel]
+      'body': description,
+      'labels': [_issueLabel, bugLabel],
     };
 
     http
@@ -221,16 +231,15 @@ class BugReportFormState extends State<BugReportForm> {
           _isButtonTapped = false;
         });
       }
-      
 
-      FocusScope.of(context).requestFocus( FocusNode());
+      FocusScope.of(context).requestFocus(FocusNode());
       displayBugToast(msg);
       setState(() {
         _isButtonTapped = false;
       });
     }).catchError((error) {
       Logger().e(error);
-      FocusScope.of(context).requestFocus( FocusNode());
+      FocusScope.of(context).requestFocus(FocusNode());
 
       final String msg =
           (error is SocketException) ? 'Falha de rede' : 'Ocorreu um erro';

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:logger/logger.dart';
 import 'package:uni/view/Widgets/form_text_field.dart';
+import 'package:email_validator/email_validator.dart';
 import 'package:uni/view/theme.dart' as theme;
 import 'package:toast/toast.dart';
 
@@ -98,8 +99,11 @@ class BugReportFormState extends State<BugReportForm> {
       labelText: 'Email em que desejas ser contactado',
       bottomMargin: 30.0,
       isOptional: true,
-      emptyText: 'Por favor coloca um email válido',
-      validatorType: FormTextFieldValidator.email,
+      formatValidator: (value) {
+        return EmailValidator.validate(value)
+            ? null
+            : 'Por favor insere um email válido';
+      },
     ));
 
     formWidget.add(consentBox(context));
@@ -212,6 +216,7 @@ class BugReportFormState extends State<BugReportForm> {
           ? null
           : () {
               if (_formKey.currentState.validate() && !_isButtonTapped) {
+                FocusScope.of(context).unfocus();
                 submitBugReport();
               }
             },
@@ -287,7 +292,7 @@ class BugReportFormState extends State<BugReportForm> {
       msg,
       context,
       duration: Toast.LENGTH_LONG,
-      gravity: Toast.TOP,
+      gravity: Toast.BOTTOM,
       backgroundColor: theme.toastColor,
       backgroundRadius: 16.0,
       textColor: Colors.white,

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -11,6 +11,7 @@ class FormTextField extends StatelessWidget {
   final int minLines;
   final int maxLines;
   final double bottomMargin;
+  final bool isOptional;
 
   FormTextField(
     this.controller,
@@ -22,29 +23,30 @@ class FormTextField extends StatelessWidget {
     this.hintText = '',
     this.emptyText = 'Por favor escreve algo',
     this.bottomMargin = 0,
+    this.isOptional = false,
   });
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
-      margin:  EdgeInsets.only(bottom: bottomMargin),
-      child:  Column(
+    return Container(
+      margin: EdgeInsets.only(bottom: bottomMargin),
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-           Text(
+          Text(
             description,
             style: Theme.of(context).textTheme.body1,
             textAlign: TextAlign.left,
           ),
-           Row(children: <Widget>[
-             Container(
-                margin:  EdgeInsets.only(right: 15),
-                child:  Icon(
+          Row(children: <Widget>[
+            Container(
+                margin: EdgeInsets.only(right: 15),
+                child: Icon(
                   icon,
                   color: Theme.of(context).primaryColor,
                 )),
             Expanded(
-                child:  TextFormField(
+                child: TextFormField(
               // margins
               minLines: minLines,
               maxLines: maxLines,
@@ -56,7 +58,7 @@ class FormTextField extends StatelessWidget {
               ),
               controller: controller,
               validator: (value) {
-                if (value.isEmpty) {
+                if (!isOptional && value.isEmpty) {
                   return emptyText;
                 }
                 return null;

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:email_validator/email_validator.dart';
-
-enum FormTextFieldValidator { none, email }
 
 class FormTextField extends StatelessWidget {
   final TextEditingController controller;
@@ -15,7 +12,7 @@ class FormTextField extends StatelessWidget {
   final int maxLines;
   final double bottomMargin;
   final bool isOptional;
-  final FormTextFieldValidator validatorType;
+  final Function formatValidator;
 
   FormTextField(
     this.controller,
@@ -25,10 +22,10 @@ class FormTextField extends StatelessWidget {
     this.maxLines = 1,
     this.labelText = '',
     this.hintText = '',
-    this.emptyText = 'Por favor preenche corretamente este campo',
+    this.emptyText = 'Por favor preenche este campo',
     this.bottomMargin = 0,
     this.isOptional = false,
-    this.validatorType = FormTextFieldValidator.none,
+    this.formatValidator = null,
   });
 
   @override
@@ -66,12 +63,7 @@ class FormTextField extends StatelessWidget {
                 if (value.isEmpty) {
                   return isOptional ? null : emptyText;
                 }
-                switch (validatorType) {
-                  case FormTextFieldValidator.email:
-                    return EmailValidator.validate(value) ? null : emptyText;
-                  default:
-                    return null;
-                }
+                return formatValidator != null ? formatValidator(value) : null;
               },
             ))
           ])

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:email_validator/email_validator.dart';
+
+enum FormTextFieldValidator { none, email }
 
 class FormTextField extends StatelessWidget {
   final TextEditingController controller;
@@ -12,6 +15,7 @@ class FormTextField extends StatelessWidget {
   final int maxLines;
   final double bottomMargin;
   final bool isOptional;
+  final FormTextFieldValidator validatorType;
 
   FormTextField(
     this.controller,
@@ -21,9 +25,10 @@ class FormTextField extends StatelessWidget {
     this.maxLines = 1,
     this.labelText = '',
     this.hintText = '',
-    this.emptyText = 'Por favor escreve algo',
+    this.emptyText = 'Por favor preenche corretamente este campo',
     this.bottomMargin = 0,
     this.isOptional = false,
+    this.validatorType = FormTextFieldValidator.none,
   });
 
   @override
@@ -58,10 +63,15 @@ class FormTextField extends StatelessWidget {
               ),
               controller: controller,
               validator: (value) {
-                if (!isOptional && value.isEmpty) {
-                  return emptyText;
+                if (value.isEmpty) {
+                  return isOptional ? null : emptyText;
                 }
-                return null;
+                switch (validatorType) {
+                  case FormTextFieldValidator.email:
+                    return EmailValidator.validate(value) ? null : emptyText;
+                  default:
+                    return null;
+                }
               },
             ))
           ])

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   logger: ^0.8.3
   url_launcher: ^4.1.0
   flutter_markdown: ^0.3.5
+  email_validator: ^1.0.6
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
[Closes] #302 
User can now include their email in a bug report. A hint is provided that the info will be public on GitHub when the user touches the box.

![email-bug-report](https://user-images.githubusercontent.com/61701401/107945795-0c728800-6f88-11eb-8e00-72f70cdfde8a.jpg)


# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code