### PR TITLE
Improve user login experience

### DIFF
--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -288,7 +288,7 @@ class _LoginPageViewState extends State<LoginPageView> {
         focusedBorder: genericDecoration.focusedBorder,
         suffixIcon: IconButton(
           icon: Icon(
-            _obscurePasswordInput ? Icons.visibility_off : Icons.visibility,
+            _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
           ),
           onPressed: _toggleObscurePasswordInput,
           color: Theme.of(context).accentColor,

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -54,7 +54,7 @@ class _LoginPageViewState extends State<LoginPageView> {
     });
   }
 
-  void _toggleShowPassword() {
+  void _toggleObscurePasswordInput() {
     setState(() {
       _obscurePasswordInput = !_obscurePasswordInput;
     });
@@ -104,7 +104,7 @@ class _LoginPageViewState extends State<LoginPageView> {
       msg,
       context,
       duration: Toast.LENGTH_LONG,
-      gravity: Toast.BOTTOM,
+      gravity: Toast.TOP,
       backgroundColor: toastColor,
       backgroundRadius: 16.0,
       textColor: Colors.white,
@@ -169,7 +169,7 @@ class _LoginPageViewState extends State<LoginPageView> {
         FocusScope.of(context).requestFocus(passwordFocus);
       },
       textInputAction: TextInputAction.next,
-      textAlign: TextAlign.center,
+      textAlign: TextAlign.left,
       decoration: textFieldDecoration('número de estudante'),
       validator: (String value) => value.isEmpty ? 'Preencha este campo' : null,
     );
@@ -189,15 +189,9 @@ class _LoginPageViewState extends State<LoginPageView> {
         },
         textInputAction: TextInputAction.done,
         obscureText: _obscurePasswordInput,
-        textAlign: TextAlign.center,
-        decoration: InputDecoration(
-            hintText: 'palavra-passe',
-            suffix: InkWell(
-              onTap: _toggleShowPassword,
-              child: Icon(
-                _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
-              ),
-            )),
+        enableInteractiveSelection: !_obscurePasswordInput,
+        textAlign: TextAlign.left,
+        decoration: passwordFieldDecoration('palavra-passe'),
         validator: (String value) =>
             value.isEmpty ? 'Preencha este campo' : null);
   }
@@ -278,10 +272,27 @@ class _LoginPageViewState extends State<LoginPageView> {
           color: Colors.white70,
         ),
         hintText: placeholder,
-        contentPadding: EdgeInsets.fromLTRB(20.0, 10.0, 20.0, 10.0),
+        contentPadding: EdgeInsets.fromLTRB(10.0, 10.0, 10.0, 10.0),
         border: UnderlineInputBorder(),
         focusedBorder: UnderlineInputBorder(
             borderSide: BorderSide(color: Colors.white, width: 3)));
+  }
+
+  InputDecoration passwordFieldDecoration(String placeholder) {
+    final genericDecoration = textFieldDecoration(placeholder);
+    return InputDecoration(
+        errorStyle: genericDecoration.errorStyle,
+        hintText: genericDecoration.hintText,
+        contentPadding: genericDecoration.contentPadding,
+        border: genericDecoration.border,
+        focusedBorder: genericDecoration.focusedBorder,
+        suffixIcon: IconButton(
+          icon: Icon(
+            _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
+          ),
+          onPressed: _toggleObscurePasswordInput,
+          color: Theme.of(context).accentColor,
+        ));
   }
 
   createSafeLoginButton(BuildContext context) {

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -57,21 +57,21 @@ class _LoginPageViewState extends State<LoginPageView> {
   Widget build(BuildContext context) {
     final MediaQueryData queryData = MediaQuery.of(context);
 
-    return  Scaffold(
+    return Scaffold(
         backgroundColor: primaryColor,
         body: WillPopScope(
             child: Padding(
                 padding: EdgeInsets.only(
                     left: queryData.size.width / 8,
                     right: queryData.size.width / 8),
-                child:  ListView(
+                child: ListView(
                   children: getWidgets(context, queryData),
                 )),
             onWillPop: () => onWillPop(context)));
   }
 
   List<Widget> getWidgets(BuildContext context, MediaQueryData queryData) {
-    final List<Widget> widgets =  List();
+    final List<Widget> widgets = List();
 
     widgets.add(
         Padding(padding: EdgeInsets.only(bottom: queryData.size.height / 20)));
@@ -106,7 +106,7 @@ class _LoginPageViewState extends State<LoginPageView> {
 
   Future<void> exitAppWaiter() async {
     _exitApp = true;
-    await  Future.delayed(Duration(seconds: 2));
+    await Future.delayed(Duration(seconds: 2));
     _exitApp = false;
   }
 
@@ -120,8 +120,8 @@ class _LoginPageViewState extends State<LoginPageView> {
   }
 
   Widget createTitle(queryData, context) {
-    return  ConstrainedBox(
-        constraints:  BoxConstraints(
+    return ConstrainedBox(
+        constraints: BoxConstraints(
           minWidth: queryData.size.width / 8,
           minHeight: queryData.size.height / 6,
         ),
@@ -136,7 +136,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   }
 
   Widget getLoginForm(MediaQueryData queryData, BuildContext context) {
-    return  Form(
+    return Form(
       key: this._formKey,
       child: SingleChildScrollView(
         child: Column(children: [
@@ -152,8 +152,8 @@ class _LoginPageViewState extends State<LoginPageView> {
 
   Widget createUsernameInput(BuildContext context) {
     return TextFormField(
-      style:  TextStyle(color: Colors.white, fontSize: 20),
-      keyboardType: TextInputType.text,
+      style: TextStyle(color: Colors.white, fontSize: 20),
+      keyboardType: TextInputType.number,
       autofocus: false,
       controller: usernameController,
       focusNode: usernameFocus,
@@ -170,7 +170,7 @@ class _LoginPageViewState extends State<LoginPageView> {
 
   Widget createPasswordInput() {
     return TextFormField(
-        style:  TextStyle(color: Colors.white, fontSize: 20),
+        style: TextStyle(color: Colors.white, fontSize: 20),
         autofocus: false,
         controller: passwordController,
         focusNode: passwordFocus,
@@ -206,7 +206,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   }
 
   Widget createLogInButton(queryData) {
-    return  Padding(
+    return Padding(
       padding: EdgeInsets.only(
           left: queryData.size.width / 7, right: queryData.size.width / 7),
       child: SizedBox(
@@ -232,12 +232,13 @@ class _LoginPageViewState extends State<LoginPageView> {
     return StoreConnector<AppState, RequestStatus>(
         converter: (store) => store.state.content['loginStatus'],
         onWillChange: (status) {
-          if (
-            status == RequestStatus.successful &&
-            StoreProvider.of<AppState>(context).
-              state.content['session'].authenticated
-          ){
-            Navigator.pushReplacementNamed(context, '/' + Constants.navPersonalArea);
+          if (status == RequestStatus.successful &&
+              StoreProvider.of<AppState>(context)
+                  .state
+                  .content['session']
+                  .authenticated) {
+            Navigator.pushReplacementNamed(
+                context, '/' + Constants.navPersonalArea);
           } else if (status == RequestStatus.failed) {
             displayToastMessage(context, 'O login falhou');
           }
@@ -245,9 +246,9 @@ class _LoginPageViewState extends State<LoginPageView> {
         builder: (context, status) {
           switch (status) {
             case RequestStatus.busy:
-              return  Container(
+              return Container(
                 height: 60.0,
-                child:  Center(child:  CircularProgressIndicator()),
+                child: Center(child: CircularProgressIndicator()),
               );
             default:
               return Container();
@@ -262,9 +263,9 @@ class _LoginPageViewState extends State<LoginPageView> {
         ),
         hintText: placeholder,
         contentPadding: EdgeInsets.fromLTRB(20.0, 10.0, 20.0, 10.0),
-        border:  UnderlineInputBorder(),
-        focusedBorder:  UnderlineInputBorder(
-            borderSide:  BorderSide(color: Colors.white, width: 3)));
+        border: UnderlineInputBorder(),
+        focusedBorder: UnderlineInputBorder(
+            borderSide: BorderSide(color: Colors.white, width: 3)));
   }
 
   createSafeLoginButton(BuildContext context) {

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -288,7 +288,7 @@ class _LoginPageViewState extends State<LoginPageView> {
         focusedBorder: genericDecoration.focusedBorder,
         suffixIcon: IconButton(
           icon: Icon(
-            _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
+            _obscurePasswordInput ? Icons.visibility_off : Icons.visibility,
           ),
           onPressed: _toggleObscurePasswordInput,
           color: Theme.of(context).accentColor,

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -35,6 +35,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   static bool _exitApp = false;
   bool _keepSignedIn = false;
+  bool _obscurePasswordInput = true;
 
   void _login(BuildContext context) {
     final store = StoreProvider.of<AppState>(context);
@@ -50,6 +51,12 @@ class _LoginPageViewState extends State<LoginPageView> {
   void _setKeepSignedIn(value) {
     setState(() {
       _keepSignedIn = value;
+    });
+  }
+
+  void _toggleShowPassword() {
+    setState(() {
+      _obscurePasswordInput = !_obscurePasswordInput;
     });
   }
 
@@ -171,6 +178,8 @@ class _LoginPageViewState extends State<LoginPageView> {
   Widget createPasswordInput() {
     return TextFormField(
         style: TextStyle(color: Colors.white, fontSize: 20),
+        enableSuggestions: false,
+        autocorrect: false,
         autofocus: false,
         controller: passwordController,
         focusNode: passwordFocus,
@@ -179,9 +188,16 @@ class _LoginPageViewState extends State<LoginPageView> {
           _login(context);
         },
         textInputAction: TextInputAction.done,
-        obscureText: true,
+        obscureText: _obscurePasswordInput,
         textAlign: TextAlign.center,
-        decoration: textFieldDecoration('palavra-passe'),
+        decoration: InputDecoration(
+            hintText: 'palavra-passe',
+            suffix: InkWell(
+              onTap: _toggleShowPassword,
+              child: Icon(
+                _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
+              ),
+            )),
         validator: (String value) =>
             value.isEmpty ? 'Preencha este campo' : null);
   }

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -104,7 +104,7 @@ class _LoginPageViewState extends State<LoginPageView> {
       msg,
       context,
       duration: Toast.LENGTH_LONG,
-      gravity: Toast.TOP,
+      gravity: Toast.BOTTOM,
       backgroundColor: toastColor,
       backgroundRadius: 16.0,
       textColor: Colors.white,
@@ -225,7 +225,12 @@ class _LoginPageViewState extends State<LoginPageView> {
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(25),
           ),
-          onPressed: () => _login(context),
+          onPressed: () {
+            if (!FocusScope.of(context).hasPrimaryFocus) {
+              FocusScope.of(context).unfocus();
+            }
+            _login(context);
+          },
           color: Colors.white,
           child: Text('Entrar',
               style: TextStyle(


### PR DESCRIPTION
Closes #221, closes #216 

Relevant changes:

- Keyboard loses focus on tapping the send button so that the toast is visible
- Text fields are now aligned left (were a bit weird centered with the eye icon)
- User number input spawns numerical keyboard instead of the complete one
- Password input field obscurity may be toggled with a switch
- Password input keyboard now has suggestions and auto correction disabled

<img src="https://user-images.githubusercontent.com/61701401/109881703-a157cf80-7c70-11eb-8e58-204fdac94d96.png" width="300">


# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [ ] Clean, well structured code
