### PR TITLE
Exam color tagging

### DIFF
--- a/app_feup/lib/model/entities/exam.dart
+++ b/app_feup/lib/model/entities/exam.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 
 var months = {
@@ -94,3 +96,9 @@ class Exam {
     return '''$subject - $year - $month - $day -  $begin-$end - $examType - $rooms - $weekDay''';
   }
 }
+
+Color examColor(Exam exam, context) {
+    return
+        (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
+        ? Theme.of(context).backgroundColor : Theme.of(context).highlightColor;
+  }

--- a/app_feup/lib/model/entities/exam.dart
+++ b/app_feup/lib/model/entities/exam.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/cupertino.dart';
-import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 
 var months = {
@@ -96,9 +94,3 @@ class Exam {
     return '''$subject - $year - $month - $day -  $begin-$end - $examType - $rooms - $weekDay''';
   }
 }
-
-Color examColor(Exam exam, context) {
-    return
-        (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
-        ? Theme.of(context).backgroundColor : Theme.of(context).highlightColor;
-  }

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -86,8 +86,7 @@ class ExamCard extends GenericCard {
           type: exam.examType,
         ),
        ),
-         color: (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
-             ? null : Theme.of(context).highlightColor,
+         color: examColor(exam, context),
        ),
     ]);
   }
@@ -112,8 +111,7 @@ class ExamCard extends GenericCard {
                     type: exam.examType,
                     reverseOrder: true)
               ]),
-          color: (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
-           ? null : Theme.of(context).highlightColor,
+          color: examColor(exam, context),
         ),
       ),
     );

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -84,6 +84,7 @@ class ExamCard extends GenericCard {
           date: exam.weekDay + ', ' + exam.day + ' de ' + exam.month),
        Container(
           child: RowContainer(
+            color: examColor(exam, context),
         child: ScheduleRow(
           subject: exam.subject,
           rooms: exam.rooms,
@@ -92,9 +93,6 @@ class ExamCard extends GenericCard {
           type: exam.examType,
         ),
        ),
-         decoration: BoxDecoration(
-             color: examColor(exam, context),
-             borderRadius: BorderRadius.all(Radius.circular(7))),
        ),
     ]);
   }
@@ -103,6 +101,7 @@ class ExamCard extends GenericCard {
     return  Container(
       margin: EdgeInsets.only(top: 8),
       child:  RowContainer(
+        color: examColor(exam, context),
         child:  Container(
           padding: EdgeInsets.all(11),
           child:  Row(
@@ -119,9 +118,6 @@ class ExamCard extends GenericCard {
                     type: exam.examType,
                     reverseOrder: true)
               ]),
-          decoration: BoxDecoration(
-              color: examColor(exam, context),
-              borderRadius: BorderRadius.all(Radius.circular(7))),
         ),
       ),
     );

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -85,7 +85,9 @@ class ExamCard extends GenericCard {
           end: exam.end,
           type: exam.examType,
         ),
-      )),
+       ),
+         color: Theme.of(context).highlightColor,
+       ),
     ]);
   }
 

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -92,7 +92,9 @@ class ExamCard extends GenericCard {
           type: exam.examType,
         ),
        ),
-         color: examColor(exam, context),
+         decoration: BoxDecoration(
+             color: examColor(exam, context),
+             borderRadius: BorderRadius.all(Radius.circular(7))),
        ),
     ]);
   }
@@ -117,7 +119,9 @@ class ExamCard extends GenericCard {
                     type: exam.examType,
                     reverseOrder: true)
               ]),
-          color: examColor(exam, context),
+          decoration: BoxDecoration(
+              color: examColor(exam, context),
+              borderRadius: BorderRadius.all(Radius.circular(7))),
         ),
       ),
     );

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -16,7 +16,7 @@ import 'generic_card.dart';
 Color examColor(Exam exam, context) {
   return
     (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
-        ? Theme.of(context).backgroundColor : Theme.of(context).highlightColor;
+        ? Theme.of(context).hintColor : Theme.of(context).backgroundColor;
 }
 
 class ExamCard extends GenericCard {

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -86,7 +86,8 @@ class ExamCard extends GenericCard {
           type: exam.examType,
         ),
        ),
-         color: Theme.of(context).highlightColor,
+         color: (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
+             ? null : Theme.of(context).highlightColor,
        ),
     ]);
   }
@@ -111,7 +112,8 @@ class ExamCard extends GenericCard {
                     type: exam.examType,
                     reverseOrder: true)
               ]),
-          color: Theme.of(context).highlightColor,
+          color: (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
+           ? null : Theme.of(context).highlightColor,
         ),
       ),
     );

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -13,6 +13,12 @@ import 'package:uni/view/Widgets/schedule_row.dart';
 
 import 'generic_card.dart';
 
+Color examColor(Exam exam, context) {
+  return
+    (exam.examType.contains('''EN''')) || (exam.examType.contains('''MT'''))
+        ? Theme.of(context).backgroundColor : Theme.of(context).highlightColor;
+}
+
 class ExamCard extends GenericCard {
   ExamCard({Key key}) : super(key: key);
 

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -109,6 +109,7 @@ class ExamCard extends GenericCard {
                     type: exam.examType,
                     reverseOrder: true)
               ]),
+          color: Theme.of(context).highlightColor,
         ),
       ),
     );

--- a/app_feup/lib/view/Widgets/row_container.dart
+++ b/app_feup/lib/view/Widgets/row_container.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 class RowContainer extends StatelessWidget {
   final Widget child;
   final Color borderColor;
-  RowContainer({Key key, @required this.child, this.borderColor})
+  final Color color;
+  RowContainer({Key key, @required this.child, this.borderColor, this.color})
       : super(key: key);
 
   @override
@@ -15,6 +16,7 @@ class RowContainer extends StatelessWidget {
                   ? Theme.of(context).accentColor
                   : this.borderColor,
               width: 0.5),
+          color: this.color,
           borderRadius: BorderRadius.all(Radius.circular(7))),
       child: this.child,
     );

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.0.0+10
+version: 1.0.0+11
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -12,7 +12,7 @@ version: 1.0.0+10
 environment:
   sdk: ">=2.7.0 <3.0.0"
   flutter: 2.0.1
-  
+
 
 dependencies:
   flutter:


### PR DESCRIPTION
Closes #315 
Tags exams from different exam periods:
- white color, for normal exams and minitests
- grey color, for extraordinary evaluation (resit exams, special ones, ...)

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
