### PR TITLE
Switch back schedule api

### DIFF
--- a/app_feup/lib/controller/parsers/parser_schedule.dart
+++ b/app_feup/lib/controller/parsers/parser_schedule.dart
@@ -18,14 +18,19 @@ Future<List<Lecture>> parseSchedule(http.Response response) async {
     final int blocks = (lecture['aula_duracao'] * 2).round();
     final String room = lecture['sala_sigla'].replaceAll(RegExp('\\+'), '\n');
     final String teacher = lecture['doc_sigla'];
+    final String classNumber = lecture['turma_sigla'];
 
-    lectures
-        .add(Lecture(subject, typeClass, day, secBegin, blocks, room, teacher));
+    lectures.add(Lecture(
+        subject, typeClass, day, secBegin, blocks, room, teacher, classNumber));
   }
 
   final lecturesList = lectures.toList();
 
   lecturesList.sort((a, b) => a.compare(b));
 
-  return lecturesList;
+  if (lecturesList.isEmpty) {
+    return Future.error(Exception('Found empty schedule'));
+  } else {
+    return lecturesList;
+  }
 }

--- a/app_feup/lib/model/entities/lecture.dart
+++ b/app_feup/lib/model/entities/lecture.dart
@@ -23,7 +23,7 @@ class Lecture {
   int startTimeSeconds;
 
   Lecture(String subject, String typeClass, int day, int startTimeSeconds,
-      int blocks, String room, String teacher) {
+      int blocks, String room, String teacher, String classNumber) {
     this.subject = subject;
     this.typeClass = typeClass;
     this.room = room;
@@ -31,6 +31,7 @@ class Lecture {
     this.day = day;
     this.blocks = blocks;
     this.startTimeSeconds = startTimeSeconds;
+    this.classNumber = classNumber;
 
     this.startTime = (startTimeSeconds ~/ 3600).toString().padLeft(2, '0') +
         ':' +
@@ -71,7 +72,7 @@ class Lecture {
 
   static Lecture clone(Lecture lec) {
     return Lecture(lec.subject, lec.typeClass, lec.day, lec.startTimeSeconds,
-        lec.blocks, lec.room, lec.teacher);
+        lec.blocks, lec.room, lec.teacher, lec.classNumber);
   }
 
   static Lecture cloneHtml(Lecture lec) {

--- a/app_feup/lib/redux/action_creators.dart
+++ b/app_feup/lib/redux/action_creators.dart
@@ -15,6 +15,7 @@ import 'package:uni/controller/parsers/parser_exams.dart';
 import 'package:uni/controller/parsers/parser_print_balance.dart';
 import 'package:uni/controller/parsers/parser_fees.dart';
 import 'package:uni/controller/parsers/parser_courses.dart';
+import 'package:uni/controller/schedule_fetcher/schedule_fetcher_api.dart';
 import 'package:uni/controller/schedule_fetcher/schedule_fetcher_html.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/course.dart';
@@ -245,8 +246,7 @@ ThunkAction<AppState> getUserSchedule(Completer<Null> action) {
       store.dispatch(SetScheduleStatusAction(RequestStatus.busy));
 
       //TODO: Go back to API whenever it is fixed: https://github.com/NIAEFEUP/project-schrodinger/issues/300
-      final List<Lecture> lectures =
-          await ScheduleFetcherHtml().getLectures(store);
+      final List<Lecture> lectures = await getLectures(store);
 
       // Updates local database according to the information fetched -- Lectures
       final Tuple2<String, String> userPersistentInfo =
@@ -264,6 +264,12 @@ ThunkAction<AppState> getUserSchedule(Completer<Null> action) {
     }
     action.complete();
   };
+}
+
+Future<List<Lecture>> getLectures(Store<AppState> store) {
+  return ScheduleFetcherApi()
+      .getLectures(store)
+      .catchError((e) => ScheduleFetcherHtml().getLectures(store));
 }
 
 ThunkAction<AppState> setInitialStoreState() {

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.0.0+13
+version: 1.0.0+14
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #336 

Switch back schedule api. Using html parser if schedule api is down or returns empty (as it did before)

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
