### PR TITLE
Refactor/fetch theme data

### DIFF
--- a/app_feup/lib/controller/local_storage/image_offline_storage.dart
+++ b/app_feup/lib/controller/local_storage/image_offline_storage.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:image/image.dart';
 import 'package:connectivity/connectivity.dart';
 
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' show DefaultCacheManager;
 import 'package:path_provider/path_provider.dart';
 
 Future<String> get _localPath async {

--- a/app_feup/lib/controller/logout.dart
+++ b/app_feup/lib/controller/logout.dart
@@ -5,7 +5,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' show DefaultCacheManager;
 import 'package:uni/controller/local_storage/app_bus_stop_database.dart';
 import 'package:uni/controller/local_storage/app_courses_database.dart';
 import 'package:uni/controller/local_storage/app_exams_database.dart';

--- a/app_feup/lib/main.dart
+++ b/app_feup/lib/main.dart
@@ -58,7 +58,7 @@ class MyAppState extends State<MyApp> {
       store: state,
       child: MaterialApp(
           title: 'uni',
-          theme: applicationTheme,
+          theme: applicationLightTheme,
           home: SplashScreen(),
           navigatorKey: NavigationService.navigatorKey,
           // ignore: missing_return

--- a/app_feup/lib/view/Pages/about_page_view.dart
+++ b/app_feup/lib/view/Pages/about_page_view.dart
@@ -17,7 +17,7 @@ class AboutPageViewState extends GeneralPageViewState {
         Container(
             child: SvgPicture.asset(
           'assets/images/ni_logo.svg',
-          color: Theme.of(context).primaryColor,
+          color: Theme.of(context).accentColor,
           width: queryData.size.height / 7,
           height: queryData.size.height / 7,
         )),

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -9,7 +9,6 @@ import 'package:uni/view/Pages/secondary_page_view.dart';
 import 'package:uni/view/Widgets/bus_stop_row.dart';
 import 'package:uni/view/Widgets/last_update_timestamp.dart';
 import 'package:uni/view/Widgets/page_title.dart';
-import 'package:uni/view/theme.dart';
 
 class BusStopNextArrivalsPage extends StatefulWidget {
   @override

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -28,7 +28,7 @@ class BusStopNextArrivalsPageState extends SecondaryPageViewState {
             store.state.content['configuredBusStops'],
             store.state.content['busstopStatus']),
         builder: (context, busstops) {
-          return  ListView(children: [
+          return ListView(children: [
             NextArrivals(busstops.item1, busstops.item2, busstops.item3)
           ]);
         });
@@ -44,7 +44,7 @@ class NextArrivals extends StatefulWidget {
 
   @override
   _NextArrivalsState createState() =>
-       _NextArrivalsState(trips, busConfig, busStopStatus);
+      _NextArrivalsState(trips, busConfig, busStopStatus);
 }
 
 class _NextArrivalsState extends State<NextArrivals>
@@ -59,7 +59,7 @@ class _NextArrivalsState extends State<NextArrivals>
   @override
   void initState() {
     super.initState();
-    tabController =  TabController(vsync: this, length: busConfig.length);
+    tabController = TabController(vsync: this, length: busConfig.length);
   }
 
   @override
@@ -72,50 +72,47 @@ class _NextArrivalsState extends State<NextArrivals>
   Widget build(BuildContext context) {
     switch (busStopStatus) {
       case RequestStatus.successful:
-        return  Container(
+        return Container(
             height: MediaQuery.of(context).size.height,
             child: Column(children: this.requestSuccessful(context)));
         break;
       case RequestStatus.busy:
-        return  Container(
+        return Container(
             height: MediaQuery.of(context).size.height,
             child: Column(children: this.requestBusy(context)));
         break;
       case RequestStatus.failed:
-        return  Container(
+        return Container(
             height: MediaQuery.of(context).size.height,
             child: Column(children: this.requestFailed(context)));
         break;
       default:
-        return  Container();
+        return Container();
         break;
     }
   }
 
   List<Widget> requestSuccessful(context) {
-    final List<Widget> result =  <Widget>[];
+    final List<Widget> result = <Widget>[];
 
     result.addAll(this.getHeader(context));
 
     if (busConfig.isNotEmpty) {
       result.addAll(this.getContent(context));
     } else {
-      result.add( Container(
+      result.add(Container(
           child: Text('Não se encontram configuradas paragens',
-              style: Theme.of(context)
-                  .textTheme
-                  .headline4
-                  .apply(color: greyTextColor))));
+              style: Theme.of(context).textTheme.headline4)));
     }
 
     return result;
   }
 
   List<Widget> requestBusy(BuildContext context) {
-    final List<Widget> result =  <Widget>[];
+    final List<Widget> result = <Widget>[];
 
     result.add(getPageTitle());
-    result.add( Container(
+    result.add(Container(
         padding: EdgeInsets.all(22.0),
         child: Center(child: CircularProgressIndicator())));
 
@@ -129,18 +126,15 @@ class _NextArrivalsState extends State<NextArrivals>
   }
 
   List<Widget> requestFailed(BuildContext context) {
-    final List<Widget> result =  <Widget>[];
+    final List<Widget> result = <Widget>[];
 
     result.addAll(this.getHeader(context));
-    result.add( Container(
+    result.add(Container(
         padding: EdgeInsets.only(bottom: 12.0),
         child: Text('Não foi possível obter informação',
             maxLines: 2,
             overflow: TextOverflow.fade,
-            style: Theme.of(context)
-                .textTheme
-                .headline4
-                .apply(color: primaryColor))));
+            style: Theme.of(context).textTheme.bodyText1)));
 
     return result;
   }
@@ -148,22 +142,22 @@ class _NextArrivalsState extends State<NextArrivals>
   List<Widget> getHeader(context) {
     return [
       getPageTitle(),
-       Container(
+      Container(
         padding: EdgeInsets.all(8.0),
-        child:  Row(
+        child: Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: <Widget>[
-               Container(
+              Container(
                 padding: EdgeInsets.only(left: 10.0),
-                child:  LastUpdateTimeStamp(),
+                child: LastUpdateTimeStamp(),
               ),
-               IconButton(
-                  icon:  Icon(Icons.edit),
+              IconButton(
+                  icon: Icon(Icons.edit),
                   color: Theme.of(context).primaryColor,
                   onPressed: () => Navigator.push(
                       context,
-                       MaterialPageRoute(
-                          builder: (context) =>  BusStopSelectionPage())))
+                      MaterialPageRoute(
+                          builder: (context) => BusStopSelectionPage())))
             ]),
       )
     ];
@@ -174,16 +168,16 @@ class _NextArrivalsState extends State<NextArrivals>
     final Color labelColor = Color.fromARGB(255, 0x50, 0x50, 0x50);
 
     return [
-       Container(
+      Container(
         decoration: const BoxDecoration(
           border: Border(
             bottom: BorderSide(width: 1.0, color: Colors.grey),
           ),
         ),
         constraints: BoxConstraints(maxHeight: 150.0),
-        child:  Material(
+        child: Material(
           color: Colors.white,
-          child:  TabBar(
+          child: TabBar(
             controller: tabController,
             isScrollable: true,
             unselectedLabelColor: labelColor,
@@ -195,10 +189,10 @@ class _NextArrivalsState extends State<NextArrivals>
           ),
         ),
       ),
-       Expanded(
+      Expanded(
         child: Container(
           padding: EdgeInsets.only(bottom: 92.0),
-          child:  TabBarView(
+          child: TabBarView(
             controller: tabController,
             children: getEachBusStopInfo(context),
           ),
@@ -210,24 +204,24 @@ class _NextArrivalsState extends State<NextArrivals>
   List<Widget> createTabs(queryData) {
     final List<Widget> tabs = <Widget>[];
     busConfig.forEach((stopCode, stopData) {
-      tabs.add( Container(
+      tabs.add(Container(
         width: queryData.size.width /
             (busConfig.length < 3 ? busConfig.length : 3),
-        child:  Tab(text: stopCode),
+        child: Tab(text: stopCode),
       ));
     });
     return tabs;
   }
 
   List<Widget> getEachBusStopInfo(context) {
-    final List<Widget> rows =  <Widget>[];
+    final List<Widget> rows = <Widget>[];
 
     busConfig.forEach((stopCode, stopData) {
-      rows.add( ListView(children: <Widget>[
-         Container(
+      rows.add(ListView(children: <Widget>[
+        Container(
             padding:
                 EdgeInsets.only(top: 8.0, bottom: 8.0, left: 22.0, right: 22.0),
-            child:  BusStopRow(
+            child: BusStopRow(
               stopCode: stopCode,
               trips: trips[stopCode],
               stopCodeShow: false,

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -164,23 +164,19 @@ class _NextArrivalsState extends State<NextArrivals>
 
   List<Widget> getContent(BuildContext context) {
     final MediaQueryData queryData = MediaQuery.of(context);
-    final Color labelColor = Color.fromARGB(255, 0x50, 0x50, 0x50);
 
     return [
       Container(
         decoration: const BoxDecoration(
           border: Border(
-            bottom: BorderSide(width: 1.0, color: Colors.grey),
+            bottom: BorderSide(width: 1.0),
           ),
         ),
         constraints: BoxConstraints(maxHeight: 150.0),
         child: Material(
-          color: Colors.white,
           child: TabBar(
             controller: tabController,
             isScrollable: true,
-            unselectedLabelColor: labelColor,
-            labelColor: labelColor,
             indicatorWeight: 3.0,
             indicatorColor: Theme.of(context).primaryColor,
             labelPadding: EdgeInsets.all(0.0),

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -152,7 +152,7 @@ class _NextArrivalsState extends State<NextArrivals>
               ),
               IconButton(
                   icon: Icon(Icons.edit),
-                  color: Theme.of(context).primaryColor,
+                  color: Theme.of(context).accentColor,
                   onPressed: () => Navigator.push(
                       context,
                       MaterialPageRoute(
@@ -177,9 +177,6 @@ class _NextArrivalsState extends State<NextArrivals>
           child: TabBar(
             controller: tabController,
             isScrollable: true,
-            indicatorWeight: 3.0,
-            indicatorColor: Theme.of(context).primaryColor,
-            labelPadding: EdgeInsets.all(0.0),
             tabs: createTabs(queryData),
           ),
         ),

--- a/app_feup/lib/view/Pages/bus_stop_selection_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_selection_page.dart
@@ -16,14 +16,14 @@ class BusStopSelectionPage extends StatefulWidget {
 
 class BusStopSelectionPageState extends UnnamedPageView {
   final double borderRadius = 15.0;
-  final DateTime now =  DateTime.now();
+  final DateTime now = DateTime.now();
 
   final db = AppBusStopDatabase();
-  final Map<String, BusStopData> configuredStops =  Map();
-  final List<String> suggestionsList =  [];
+  final Map<String, BusStopData> configuredStops = Map();
+  final List<String> suggestionsList = [];
 
   List<Widget> getStopsTextList() {
-    final List<Widget> stops =  [];
+    final List<Widget> stops = [];
     configuredStops.forEach((stopCode, stopData) {
       stops.add(Text(stopCode));
     });
@@ -36,16 +36,9 @@ class BusStopSelectionPageState extends UnnamedPageView {
     return StoreConnector<AppState, Map<String, BusStopData>>(
       converter: (store) => store.state.content['configuredBusStops'],
       builder: (context, busStops) {
-        final List<Widget> rows =  [];
+        final List<Widget> rows = [];
         busStops.forEach((stopCode, stopData) =>
             rows.add(BusStopSelectionRow(stopCode, stopData)));
-        final buttonStyle = ElevatedButton.styleFrom(
-            primary: Theme.of(context).primaryColor,
-            padding: const EdgeInsets.all(0.0),
-            shape: RoundedRectangleBorder(
-              borderRadius:  BorderRadius.circular(12.0),
-            ),
-        );
 
         return ListView(
             padding: EdgeInsets.only(
@@ -55,7 +48,8 @@ class BusStopSelectionPageState extends UnnamedPageView {
               Container(child: PageTitle(name: 'Paragens Configuradas')),
               Container(
                   padding: EdgeInsets.all(20.0),
-                  child: Text('''As paragens favoritas serão apresentadas no widget \'Paragens\' dos favoritos. As restantes serão apresentadas apenas na página.''',
+                  child: Text(
+                      '''As paragens favoritas serão apresentadas no widget \'Paragens\' dos favoritos. As restantes serão apresentadas apenas na página.''',
                       textAlign: TextAlign.center)),
               Column(children: rows),
               Container(
@@ -67,30 +61,14 @@ class BusStopSelectionPageState extends UnnamedPageView {
                         ElevatedButton(
                           onPressed: () => showSearch(
                               context: context, delegate: BusStopSearch()),
-                          style: buttonStyle,
                           child: Container(
-                            padding: const EdgeInsets.all(15.0),
-                            child: Text('Adicionar',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .headline4
-                                    .apply(
-                                        color: Colors.white,
-                                        fontSizeDelta: -2)),
+                            child: Text('Adicionar'),
                           ),
                         ),
                         ElevatedButton(
                           onPressed: () => Navigator.pop(context),
-                          style: buttonStyle,
                           child: Container(
-                            padding: const EdgeInsets.all(15.0),
-                            child: Text('Concluído',
-                                style: Theme.of(context)
-                                    .textTheme
-                                    .headline4
-                                    .apply(
-                                        color: Colors.white,
-                                        fontSizeDelta: -2)),
+                            child: Text('Concluído'),
                           ),
                         ),
                       ]))
@@ -98,5 +76,4 @@ class BusStopSelectionPageState extends UnnamedPageView {
       },
     );
   }
-
 }

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -21,15 +21,15 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
   }
 
   Widget getBody(BuildContext context) {
-    return  Container();
+    return Container();
   }
 
   DecorationImage getDecorageImage(File x) {
     final fallbackImage = decorageImage == null
-        ?  AssetImage('assets/images/profile_placeholder.png')
+        ? AssetImage('assets/images/profile_placeholder.png')
         : decorageImage;
 
-    final image = (x == null) ? fallbackImage :  FileImage(x);
+    final image = (x == null) ? fallbackImage : FileImage(x);
     final result = DecorationImage(fit: BoxFit.cover, image: image);
     if (x != null) {
       decorageImage = image;
@@ -49,8 +49,8 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
         return () => handleRefresh(store);
       },
       builder: (context, refresh) {
-        return  RefreshIndicator(
-            key:  GlobalKey<RefreshIndicatorState>(),
+        return RefreshIndicator(
+            key: GlobalKey<RefreshIndicatorState>(),
             child: child,
             onRefresh: refresh,
             color: Theme.of(context).primaryColor);
@@ -59,10 +59,10 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
   }
 
   Widget getScaffold(BuildContext context, Widget body) {
-    return  Scaffold(
+    return Scaffold(
       backgroundColor: Theme.of(context).backgroundColor,
       appBar: buildAppBar(context),
-      drawer:  NavigationDrawer(parentContext: context),
+      drawer: NavigationDrawer(parentContext: context),
       body: this.refreshState(context, body),
     );
   }
@@ -70,17 +70,17 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
   AppBar buildAppBar(BuildContext context) {
     final MediaQueryData queryData = MediaQuery.of(context);
 
-    return  AppBar(
+    return AppBar(
       bottom: PreferredSize(
         preferredSize: Size.zero,
         child: Container(
           margin: EdgeInsets.only(left: borderMargin, right: borderMargin),
-          color: Theme.of(context).accentColor,
+          color: Theme.of(context).dividerColor,
           height: 1.5,
         ),
       ),
       elevation: 0,
-      iconTheme:  IconThemeData(color: Theme.of(context).primaryColor),
+      iconTheme: IconThemeData(color: Theme.of(context).primaryColor),
       backgroundColor: Theme.of(context).backgroundColor,
       titleSpacing: 0.0,
       title: ButtonTheme(
@@ -91,7 +91,7 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
           child: TextButton(
             onPressed: () {
               final currentRouteName = ModalRoute.of(context).settings.name;
-              if(currentRouteName != Constants.navPersonalArea){
+              if (currentRouteName != Constants.navPersonalArea) {
                 Navigator.pushNamed(context, '/${Constants.navPersonalArea}');
               }
             },
@@ -113,8 +113,8 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
             AsyncSnapshot<DecorationImage> decorationImage) {
           return TextButton(
             onPressed: () => {
-              Navigator.push(context,
-                   MaterialPageRoute(builder: (__) =>  ProfilePage()))
+              Navigator.push(
+                  context, MaterialPageRoute(builder: (__) => ProfilePage()))
             },
             child: Container(
                 width: 40.0,

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -53,14 +53,14 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
             key: GlobalKey<RefreshIndicatorState>(),
             child: child,
             onRefresh: refresh,
-            color: Theme.of(context).primaryColor);
+            color: Theme.of(context).accentColor);
       },
     );
   }
 
   Widget getScaffold(BuildContext context, Widget body) {
     return Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: buildAppBar(context),
       drawer: NavigationDrawer(parentContext: context),
       body: this.refreshState(context, body),
@@ -80,8 +80,8 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
         ),
       ),
       elevation: 0,
-      iconTheme: IconThemeData(color: Theme.of(context).primaryColor),
-      backgroundColor: Theme.of(context).backgroundColor,
+      iconTheme: IconThemeData(color: Theme.of(context).accentColor),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       titleSpacing: 0.0,
       title: ButtonTheme(
           minWidth: 0,

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -60,7 +60,6 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
 
   Widget getScaffold(BuildContext context, Widget body) {
     return Scaffold(
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: buildAppBar(context),
       drawer: NavigationDrawer(parentContext: context),
       body: this.refreshState(context, body),

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -64,7 +64,7 @@ class _LoginPageViewState extends State<LoginPageView> {
     final MediaQueryData queryData = MediaQuery.of(context);
 
     return Scaffold(
-        backgroundColor: Theme.of(context).primaryColor,
+        backgroundColor: Theme.of(context).accentColor,
         body: WillPopScope(
             child: Padding(
                 padding: EdgeInsets.only(
@@ -218,7 +218,7 @@ class _LoginPageViewState extends State<LoginPageView> {
           },
           child: Text('Entrar',
               style: TextStyle(
-                  color: Theme.of(context).primaryColor,
+                  color: Theme.of(context).accentColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 20),
               textAlign: TextAlign.center),
@@ -280,7 +280,7 @@ class _LoginPageViewState extends State<LoginPageView> {
             _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
           ),
           onPressed: _toggleObscurePasswordInput,
-          color: Theme.of(context).accentColor,
+          color: Colors.white70,
         ));
   }
 

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -257,6 +257,7 @@ class _LoginPageViewState extends State<LoginPageView> {
 
   InputDecoration textFieldDecoration(String placeholder) {
     return InputDecoration(
+        hintStyle: TextStyle(color: Colors.white),
         errorStyle: TextStyle(
           color: Colors.white70,
         ),
@@ -270,6 +271,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   InputDecoration passwordFieldDecoration(String placeholder) {
     final genericDecoration = textFieldDecoration(placeholder);
     return InputDecoration(
+        hintStyle: genericDecoration.hintStyle,
         errorStyle: genericDecoration.errorStyle,
         hintText: genericDecoration.hintText,
         contentPadding: genericDecoration.contentPadding,
@@ -280,7 +282,7 @@ class _LoginPageViewState extends State<LoginPageView> {
             _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
           ),
           onPressed: _toggleObscurePasswordInput,
-          color: Colors.white70,
+          color: Colors.white,
         ));
   }
 

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
-import 'package:toast/toast.dart';
+import 'package:uni/view/Widgets/toast_message.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/redux/action_creators.dart';
 import 'package:uni/view/Widgets/terms_and_conditions.dart';
@@ -99,18 +99,6 @@ class _LoginPageViewState extends State<LoginPageView> {
     return widgets;
   }
 
-  void displayToastMessage(BuildContext context, String msg) {
-    Toast.show(
-      msg,
-      context,
-      duration: Toast.LENGTH_LONG,
-      gravity: Toast.BOTTOM,
-      backgroundColor: toastColor,
-      backgroundRadius: 16.0,
-      textColor: Colors.white,
-    );
-  }
-
   Future<void> exitAppWaiter() async {
     _exitApp = true;
     await Future.delayed(Duration(seconds: 2));
@@ -121,7 +109,7 @@ class _LoginPageViewState extends State<LoginPageView> {
     if (_exitApp) {
       return Future.value(true);
     }
-    displayToastMessage(context, 'Pressione novamente para sair');
+    ToastMessage.display(context, 'Pressione novamente para sair');
     exitAppWaiter();
     return Future.value(false);
   }
@@ -252,7 +240,7 @@ class _LoginPageViewState extends State<LoginPageView> {
             Navigator.pushReplacementNamed(
                 context, '/' + Constants.navPersonalArea);
           } else if (status == RequestStatus.failed) {
-            displayToastMessage(context, 'O login falhou');
+            ToastMessage.display(context, 'O login falhou');
           }
         },
         builder: (context, status) {

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -5,7 +5,6 @@ import 'package:uni/view/Widgets/toast_message.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/redux/action_creators.dart';
 import 'package:uni/view/Widgets/terms_and_conditions.dart';
-import 'package:uni/view/theme.dart';
 import 'package:uni/utils/constants.dart' as Constants;
 
 import '../../model/app_state.dart';
@@ -65,7 +64,7 @@ class _LoginPageViewState extends State<LoginPageView> {
     final MediaQueryData queryData = MediaQuery.of(context);
 
     return Scaffold(
-        backgroundColor: primaryColor,
+        backgroundColor: Theme.of(context).primaryColor,
         body: WillPopScope(
             child: Padding(
                 padding: EdgeInsets.only(
@@ -88,7 +87,7 @@ class _LoginPageViewState extends State<LoginPageView> {
     widgets.add(getLoginForm(queryData, context));
     widgets.add(
         Padding(padding: EdgeInsets.only(bottom: queryData.size.height / 15)));
-    widgets.add(createLogInButton(queryData));
+    widgets.add(createLogInButton(queryData, context));
     widgets.add(
         Padding(padding: EdgeInsets.only(bottom: queryData.size.height / 35)));
     widgets.add(createStatusWidget(context));
@@ -198,7 +197,7 @@ class _LoginPageViewState extends State<LoginPageView> {
     );
   }
 
-  Widget createLogInButton(queryData) {
+  Widget createLogInButton(queryData, BuildContext context) {
     return Padding(
       padding: EdgeInsets.only(
           left: queryData.size.width / 7, right: queryData.size.width / 7),
@@ -219,7 +218,7 @@ class _LoginPageViewState extends State<LoginPageView> {
           },
           child: Text('Entrar',
               style: TextStyle(
-                  color: primaryColor,
+                  color: Theme.of(context).primaryColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 20),
               textAlign: TextAlign.center),

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -159,7 +159,7 @@ class _LoginPageViewState extends State<LoginPageView> {
       textInputAction: TextInputAction.next,
       textAlign: TextAlign.left,
       decoration: textFieldDecoration('número de estudante'),
-      validator: (String value) => value.isEmpty ? 'Preencha este campo' : null,
+      validator: (String value) => value.isEmpty ? 'Preenche este campo' : null,
     );
   }
 
@@ -181,7 +181,7 @@ class _LoginPageViewState extends State<LoginPageView> {
         textAlign: TextAlign.left,
         decoration: passwordFieldDecoration('palavra-passe'),
         validator: (String value) =>
-            value.isEmpty ? 'Preencha este campo' : null);
+            value.isEmpty ? 'Preenche este campo' : null);
   }
 
   Widget createSaveDataCheckBox() {

--- a/app_feup/lib/view/Pages/profile_page_view.dart
+++ b/app_feup/lib/view/Pages/profile_page_view.dart
@@ -9,7 +9,6 @@ import 'package:uni/view/Pages/unnamed_page_view.dart';
 import 'package:uni/view/Widgets/account_info_card.dart';
 import 'package:uni/view/Widgets/course_info_card.dart';
 import 'package:uni/view/Widgets/print_info_card.dart';
-import 'package:uni/view/theme.dart';
 
 class ProfilePageView extends StatefulWidget {
   final String name;
@@ -38,7 +37,6 @@ class ProfilePageViewState extends UnnamedPageView {
   final String email;
   final Map<String, String> currentState;
   final List<Course> courses;
-  
 
   @override
   Widget getBody(BuildContext context) {
@@ -51,7 +49,7 @@ class ProfilePageViewState extends UnnamedPageView {
   }
 
   List<Widget> childrenList(BuildContext context) {
-    final List<Widget> list =  [];
+    final List<Widget> list = [];
     list.add(Padding(padding: const EdgeInsets.all(5.0)));
     list.add(profileInfo(context));
     list.add(Padding(padding: const EdgeInsets.all(5.0)));
@@ -87,16 +85,16 @@ class ProfilePageViewState extends UnnamedPageView {
             Text(name,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                    color: greyTextColor,
+                    //color: greyTextColor,
                     fontSize: 20.0,
                     fontWeight: FontWeight.w400)),
             Padding(padding: const EdgeInsets.all(5.0)),
             Text(email,
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                    color: greyTextColor,
+                    //color: greyTextColor,
                     fontSize: 18.0,
-                    fontWeight: FontWeight.w200)),
+                    fontWeight: FontWeight.w300)),
           ],
         ),
       ),

--- a/app_feup/lib/view/Pages/profile_page_view.dart
+++ b/app_feup/lib/view/Pages/profile_page_view.dart
@@ -1,5 +1,4 @@
 import 'dart:io';
-
 import 'package:uni/controller/load_info.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/course.dart';
@@ -58,7 +57,7 @@ class ProfilePageViewState extends UnnamedPageView {
           course: courses[i],
           courseState:
               currentState == null ? '?' : currentState[courses[i].name]));
-      list.add(Padding(padding: const EdgeInsets.all(10.0)));
+      list.add(Padding(padding: const EdgeInsets.all(5.0)));
     }
     list.add(PrintInfoCard());
     list.add(Padding(padding: const EdgeInsets.all(5.0)));
@@ -84,17 +83,11 @@ class ProfilePageViewState extends UnnamedPageView {
             Padding(padding: const EdgeInsets.all(8.0)),
             Text(name,
                 textAlign: TextAlign.center,
-                style: TextStyle(
-                    //color: greyTextColor,
-                    fontSize: 20.0,
-                    fontWeight: FontWeight.w400)),
+                style: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w400)),
             Padding(padding: const EdgeInsets.all(5.0)),
             Text(email,
                 textAlign: TextAlign.center,
-                style: TextStyle(
-                    //color: greyTextColor,
-                    fontSize: 18.0,
-                    fontWeight: FontWeight.w300)),
+                style: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300)),
           ],
         ),
       ),

--- a/app_feup/lib/view/Pages/schedule_page_view.dart
+++ b/app_feup/lib/view/Pages/schedule_page_view.dart
@@ -23,7 +23,6 @@ class SchedulePageView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final MediaQueryData queryData = MediaQuery.of(context);
-    final Color labelColor = Color.fromARGB(255, 0x50, 0x50, 0x50);
 
     return Column(children: <Widget>[
       ListView(
@@ -33,12 +32,7 @@ class SchedulePageView extends StatelessWidget {
           PageTitle(name: 'Horário'),
           TabBar(
             controller: tabController,
-            unselectedLabelColor: labelColor,
-            labelColor: labelColor,
             isScrollable: true,
-            indicatorWeight: 3.0,
-            indicatorColor: Theme.of(context).primaryColor,
-            labelPadding: EdgeInsets.all(0.0),
             tabs: createTabs(queryData, context),
           ),
         ],

--- a/app_feup/lib/view/Pages/splash_page_view.dart
+++ b/app_feup/lib/view/Pages/splash_page_view.dart
@@ -37,7 +37,8 @@ class _SplashScreenState extends State<SplashScreen> {
         fit: StackFit.expand,
         children: <Widget>[
           Container(
-            decoration: BoxDecoration(color: applicationTheme.backgroundColor),
+            decoration:
+                BoxDecoration(color: applicationLightTheme.backgroundColor),
           ),
           Column(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -99,7 +100,6 @@ class _SplashScreenState extends State<SplashScreen> {
       await acceptTermsAndConditions();
       nextRoute = MaterialPageRoute(builder: (context) => LoginPageView());
     }
-
     Navigator.pushReplacement(context, nextRoute);
   }
 

--- a/app_feup/lib/view/Pages/splash_page_view.dart
+++ b/app_feup/lib/view/Pages/splash_page_view.dart
@@ -75,7 +75,7 @@ class _SplashScreenState extends State<SplashScreen> {
         child: SizedBox(
             child: SvgPicture.asset(
               'assets/images/logo_dark.svg',
-              color: Theme.of(context).primaryColor,
+              color: Theme.of(context).accentColor,
             ),
             width: 150.0));
   }
@@ -83,7 +83,7 @@ class _SplashScreenState extends State<SplashScreen> {
   Widget createNILogo() {
     return SvgPicture.asset(
       'assets/images/by_niaefeup.svg',
-      color: Theme.of(context).primaryColor,
+      color: Theme.of(context).accentColor,
       width: queryData.size.width * 0.45,
     );
   }

--- a/app_feup/lib/view/Pages/unnamed_page_view.dart
+++ b/app_feup/lib/view/Pages/unnamed_page_view.dart
@@ -7,7 +7,6 @@ abstract class UnnamedPageView extends GeneralPageViewState {
   @override
   getScaffold(BuildContext context, Widget body) {
     return Scaffold(
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: buildAppBar(context),
       body: this.refreshState(context, body),
     );

--- a/app_feup/lib/view/Pages/unnamed_page_view.dart
+++ b/app_feup/lib/view/Pages/unnamed_page_view.dart
@@ -1,16 +1,13 @@
-
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'general_page_view.dart';
 
-
-abstract class UnnamedPageView extends GeneralPageViewState{
+abstract class UnnamedPageView extends GeneralPageViewState {
   @override
-  getScaffold(BuildContext context, Widget body){
-    return  Scaffold(
-      backgroundColor: Theme.of(context).backgroundColor,
+  getScaffold(BuildContext context, Widget body) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: buildAppBar(context),
       body: this.refreshState(context, body),
     );

--- a/app_feup/lib/view/Widgets/back_button_exit_wrapper.dart
+++ b/app_feup/lib/view/Widgets/back_button_exit_wrapper.dart
@@ -12,25 +12,19 @@ class BackButtonExitWrapper extends StatelessWidget {
   final Widget child;
 
   Future<bool> backButton() {
-    final buttonStyle = ElevatedButton.styleFrom(
-        primary: Theme.of(context).primaryColor,
-    );
-
     return showDialog(
             context: context,
-            builder: (context) =>  AlertDialog(
-                  title:  Text('Tens a certeza que pretendes sair?'),
+            builder: (context) => AlertDialog(
+                  title: Text('Tens a certeza que pretendes sair?'),
                   actions: <Widget>[
-                     ElevatedButton(
+                    ElevatedButton(
                       onPressed: () => Navigator.of(context).pop(false),
-                      child:  Text('Não'),
-                      style: buttonStyle,
+                      child: Text('Não'),
                     ),
-                     ElevatedButton(
+                    ElevatedButton(
                       onPressed: () => SystemChannels.platform
                           .invokeMethod('SystemNavigator.pop'),
-                      child:  Text('Sim'),
-                      style: buttonStyle,
+                      child: Text('Sim'),
                     )
                   ],
                 )) ??
@@ -39,7 +33,7 @@ class BackButtonExitWrapper extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  WillPopScope(
+    return WillPopScope(
       child: this.child,
       onWillPop: () => this.backButton(),
     );

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -166,21 +166,15 @@ class BugReportFormState extends State<BugReportForm> {
 
   Widget submitButton(BuildContext context) {
     return Container(
-        child: ElevatedButton(
-      onPressed: () {
-        if (_formKey.currentState.validate() && !_isButtonTapped) {
-          submitBugReport();
-        }
-      },
-      child: Text(
-        'Enviar',
-        style: TextStyle(color: Colors.white, fontSize: 20.0),
+      child: ElevatedButton(
+        onPressed: () {
+          if (_formKey.currentState.validate() && !_isButtonTapped) {
+            submitBugReport();
+          }
+        },
+        child: Text('Enviar'),
       ),
-      style: ElevatedButton.styleFrom(
-        padding: EdgeInsets.symmetric(vertical: 10.0),
-        primary: Theme.of(context).primaryColor,
-      ),
-    ));
+    );
   }
 
   void submitBugReport() {

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -100,7 +100,7 @@ class BugReportFormState extends State<BugReportForm> {
         child: Row(
           children: <Widget>[
             Icon(Icons.bug_report,
-                color: Theme.of(context).primaryColor, size: 50.0),
+                color: Theme.of(context).accentColor, size: 50.0),
             Expanded(
                 child: Text(
               'Bugs e Sugestões',
@@ -108,7 +108,7 @@ class BugReportFormState extends State<BugReportForm> {
               textAlign: TextAlign.center,
             )),
             Icon(Icons.bug_report,
-                color: Theme.of(context).primaryColor, size: 50.0),
+                color: Theme.of(context).accentColor, size: 50.0),
           ],
         ));
   }
@@ -144,7 +144,7 @@ class BugReportFormState extends State<BugReportForm> {
                 margin: EdgeInsets.only(right: 15),
                 child: Icon(
                   Icons.bug_report,
-                  color: Theme.of(context).primaryColor,
+                  color: Theme.of(context).accentColor,
                 )),
             Expanded(
                 child: DropdownButton(

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -2,9 +2,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:logger/logger.dart';
 import 'package:uni/view/Widgets/form_text_field.dart';
-import 'package:uni/view/theme.dart' as theme;
 import 'package:uni/controller/networking/network_router.dart';
-import 'package:toast/toast.dart';
+import 'package:uni/view/Widgets/toast_message.dart';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -226,7 +225,7 @@ class BugReportFormState extends State<BugReportForm> {
       }
 
       FocusScope.of(context).requestFocus(FocusNode());
-      displayBugToast(msg);
+      ToastMessage.display(context, msg);
       setState(() {
         _isButtonTapped = false;
       });
@@ -236,23 +235,11 @@ class BugReportFormState extends State<BugReportForm> {
 
       final String msg =
           (error is SocketException) ? 'Falha de rede' : 'Ocorreu um erro';
-      displayBugToast(msg);
+      ToastMessage.display(context, msg);
       setState(() {
         _isButtonTapped = false;
       });
     });
-  }
-
-  void displayBugToast(String msg) {
-    Toast.show(
-      msg,
-      context,
-      duration: Toast.LENGTH_LONG,
-      gravity: Toast.BOTTOM,
-      backgroundColor: theme.toastColor,
-      backgroundRadius: 16.0,
-      textColor: Colors.white,
-    );
   }
 
   void clearForm() {

--- a/app_feup/lib/view/Widgets/bus_stop_card.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_card.dart
@@ -57,7 +57,7 @@ class BusStopCard extends GenericCard {
                       style: Theme.of(context)
                           .textTheme
                           .headline4
-                          .apply(color: Theme.of(context).primaryColor)),
+                          .apply(color: Theme.of(context).accentColor)),
                   IconButton(
                     icon: Icon(Icons.settings),
                     onPressed: () => Navigator.push(
@@ -88,7 +88,7 @@ class BusStopCard extends GenericCard {
                   style: Theme.of(context)
                       .textTheme
                       .headline4
-                      .apply(color: Theme.of(context).primaryColor)))
+                      .apply(color: Theme.of(context).accentColor)))
         ]);
         break;
     }
@@ -102,7 +102,7 @@ class BusStopCard extends GenericCard {
             style: Theme.of(context)
                 .textTheme
                 .headline4
-                .apply(color: Theme.of(context).primaryColor)),
+                .apply(color: Theme.of(context).accentColor)),
       ],
     );
   }

--- a/app_feup/lib/view/Widgets/bus_stop_card.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_card.dart
@@ -64,7 +64,7 @@ class BusStopCard extends GenericCard {
                         context,
                         MaterialPageRoute(
                             builder: (context) => BusStopSelectionPage())),
-                  ) // color lightgrey
+                  )
                 ]),
           );
         }

--- a/app_feup/lib/view/Widgets/bus_stop_card.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_card.dart
@@ -8,7 +8,6 @@ import 'package:uni/view/Pages/bus_stop_selection_page.dart';
 import 'package:uni/view/Widgets/bus_stop_row.dart';
 import 'package:uni/view/Widgets/last_update_timestamp.dart';
 import 'package:uni/view/Widgets/row_container.dart';
-import 'package:uni/view/theme.dart';
 
 import 'generic_card.dart';
 
@@ -58,14 +57,14 @@ class BusStopCard extends GenericCard {
                       style: Theme.of(context)
                           .textTheme
                           .headline4
-                          .apply(color: primaryColor)),
+                          .apply(color: Theme.of(context).primaryColor)),
                   IconButton(
-                      icon: Icon(Icons.settings),
-                      onPressed: () => Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => BusStopSelectionPage())),
-                      color: lightGreyTextColor)
+                    icon: Icon(Icons.settings),
+                    onPressed: () => Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (context) => BusStopSelectionPage())),
+                  ) // color lightgrey
                 ]),
           );
         }
@@ -89,7 +88,7 @@ class BusStopCard extends GenericCard {
                   style: Theme.of(context)
                       .textTheme
                       .headline4
-                      .apply(color: primaryColor)))
+                      .apply(color: Theme.of(context).primaryColor)))
         ]);
         break;
     }
@@ -98,12 +97,12 @@ class BusStopCard extends GenericCard {
   Widget getCardTitle(context) {
     return Row(
       children: <Widget>[
-        Icon(Icons.directions_bus, color: lightGreyTextColor),
+        Icon(Icons.directions_bus), // color lightgrey
         Text('STCP - Próximas Viagens',
             style: Theme.of(context)
                 .textTheme
                 .headline4
-                .apply(color: primaryColor))
+                .apply(color: Theme.of(context).primaryColor)),
       ],
     );
   }

--- a/app_feup/lib/view/Widgets/bus_stop_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_row.dart
@@ -2,7 +2,6 @@ import 'package:uni/model/entities/trip.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:uni/view/Widgets/trip_row.dart';
-import 'package:uni/view/theme.dart';
 
 class BusStopRow extends StatelessWidget {
   final String stopCode;
@@ -20,9 +19,9 @@ class BusStopRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
+    return Container(
       padding: EdgeInsets.all(4.0),
-      child:  Row(
+      child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: this.getTrips(context),
       ),
@@ -30,7 +29,7 @@ class BusStopRow extends StatelessWidget {
   }
 
   List<Widget> getTrips(context) {
-    final List<Widget> row =  <Widget>[];
+    final List<Widget> row = <Widget>[];
 
     if (stopCodeShow) {
       row.add(stopCodeRotatedContainer(context));
@@ -39,9 +38,9 @@ class BusStopRow extends StatelessWidget {
     if (trips.isEmpty) {
       row.add(noTripsContainer(context));
     } else {
-      final List<Widget> tripRows = getTripRows();
+      final List<Widget> tripRows = getTripRows(context);
 
-      row.add( Expanded(child:  Column(children: tripRows)));
+      row.add(Expanded(child: Column(children: tripRows)));
     }
 
     return row;
@@ -51,40 +50,39 @@ class BusStopRow extends StatelessWidget {
     return Text('Não há viagens planeadas de momento.',
         maxLines: 3,
         overflow: TextOverflow.ellipsis,
-        style:
-            Theme.of(context).textTheme.headline4.apply(color: greyTextColor));
+        style: Theme.of(context).textTheme.headline4);
   }
 
   Widget stopCodeRotatedContainer(context) {
-    return  Container(
+    return Container(
       padding: EdgeInsets.only(left: 4.0),
-      child:  RotatedBox(
+      child: RotatedBox(
         child: Text(this.stopCode,
             style: Theme.of(context)
                 .textTheme
                 .headline4
-                .apply(color: primaryColor)),
+                .apply(color: Theme.of(context).primaryColor)),
         quarterTurns: 3,
       ),
     );
   }
 
-  List<Widget> getTripRows() {
-    final List<Widget> tripRows =  <Widget>[];
+  List<Widget> getTripRows(BuildContext context) {
+    final List<Widget> tripRows = <Widget>[];
 
     if (singleTrip) {
-      tripRows.add( Container(
-          padding: EdgeInsets.all(12.0), child:  TripRow(trip: trips[0])));
+      tripRows.add(Container(
+          padding: EdgeInsets.all(12.0), child: TripRow(trip: trips[0])));
     } else {
       for (int i = 0; i < trips.length; i++) {
-        Color color = primaryColor;
+        Color color = Theme.of(context).primaryColor;
         if (i == trips.length - 1) color = Colors.transparent;
 
-        tripRows.add( Container(
+        tripRows.add(Container(
             padding: EdgeInsets.all(12.0),
-            decoration:  BoxDecoration(
+            decoration: BoxDecoration(
                 border: Border(bottom: BorderSide(width: 0.1, color: color))),
-            child:  TripRow(trip: trips[i])));
+            child: TripRow(trip: trips[i])));
       }
     }
 

--- a/app_feup/lib/view/Widgets/bus_stop_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_row.dart
@@ -61,7 +61,7 @@ class BusStopRow extends StatelessWidget {
             style: Theme.of(context)
                 .textTheme
                 .headline4
-                .apply(color: Theme.of(context).primaryColor)),
+                .apply(color: Theme.of(context).accentColor)),
         quarterTurns: 3,
       ),
     );
@@ -75,7 +75,7 @@ class BusStopRow extends StatelessWidget {
           padding: EdgeInsets.all(12.0), child: TripRow(trip: trips[0])));
     } else {
       for (int i = 0; i < trips.length; i++) {
-        Color color = Theme.of(context).primaryColor;
+        Color color = Theme.of(context).accentColor;
         if (i == trips.length - 1) color = Colors.transparent;
 
         tripRows.add(Container(

--- a/app_feup/lib/view/Widgets/bus_stop_search.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_search.dart
@@ -12,7 +12,7 @@ import 'package:uni/redux/action_creators.dart';
 import 'package:uni/view/Widgets/buses_form.dart';
 
 class BusStopSearch extends SearchDelegate<String> {
-  List<String> suggestionsList =  [];
+  List<String> suggestionsList = [];
   AppBusStopDatabase db;
   String stopCode;
   BusStopData stopData;
@@ -76,7 +76,7 @@ class BusStopSearch extends SearchDelegate<String> {
   }
 
   Widget busListing(BuildContext context, String suggestion) {
-    final BusesForm busesForm =  BusesForm(
+    final BusesForm busesForm = BusesForm(
         suggestion.splitMapJoin(RegExp(r'\[[A-Z0-9_]+\]'),
             onMatch: (m) => '${m.group(0).substring(1, m.group(0).length - 1)}',
             onNonMatch: (m) => ''),
@@ -90,28 +90,13 @@ class BusStopSearch extends SearchDelegate<String> {
         ),
         actions: [
           TextButton(
-              child: Text('Cancelar',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(color: Theme.of(context).primaryColor)),
-              onPressed: () => Navigator.pop(context)),
-          TextButton(
-              child: Text('Confirmar',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(color: Theme.of(context).accentColor)),
-              style: TextButton.styleFrom(
-                backgroundColor: Theme.of(context).primaryColor,
-                shape: RoundedRectangleBorder(
-                    borderRadius:  BorderRadius.circular(10.0),
-                    side: BorderSide(color: Theme.of(context).primaryColor)),
-              ),
+              child: Text('Cancelar'), onPressed: () => Navigator.pop(context)),
+          ElevatedButton(
+              child: Text('Confirmar'),
               onPressed: () async {
                 if (stopData.configuredBuses.isNotEmpty) {
                   StoreProvider.of<AppState>(context).dispatch(
-                      addUserBusStop( Completer(), stopCode, stopData));
+                      addUserBusStop(Completer(), stopCode, stopData));
                   Navigator.pop(context);
                 }
               })

--- a/app_feup/lib/view/Widgets/bus_stop_selection_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_selection_row.dart
@@ -26,12 +26,12 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
 
   Future deleteStop(BuildContext context) async {
     StoreProvider.of<AppState>(context)
-        .dispatch(removeUserBusStop( Completer(), this.stopCode));
+        .dispatch(removeUserBusStop(Completer(), this.stopCode));
   }
 
   Future toggleFavorite(BuildContext context) async {
-    StoreProvider.of<AppState>(context).dispatch(toggleFavoriteUserBusStop(
-         Completer(), this.stopCode, this.stopData));
+    StoreProvider.of<AppState>(context).dispatch(
+        toggleFavoriteUserBusStop(Completer(), this.stopCode, this.stopData));
   }
 
   @override
@@ -47,7 +47,7 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
                   left: width * 0.20,
                   right: width * 0.20),
               child: RowContainer(
-                  borderColor: Theme.of(context).primaryColor,
+                  borderColor: Theme.of(context).accentColor,
                   child: Container(
                       padding: EdgeInsets.only(left: 10.0, right: 10.0),
                       child: Row(
@@ -60,7 +60,7 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
                                       stopData.favorited
                                           ? Icons.star
                                           : Icons.star_border,
-                                      color: Theme.of(context).primaryColor),
+                                      color: Theme.of(context).accentColor),
                                   onTap: () => toggleFavorite(context)),
                               IconButton(
                                 icon: Icon(Icons.cancel),

--- a/app_feup/lib/view/Widgets/buses_form.dart
+++ b/app_feup/lib/view/Widgets/buses_form.dart
@@ -63,8 +63,7 @@ class _BusesFormState extends State<BusesForm> {
             setState(() {
               busesToAdd[i] = value;
             });
-          },
-          activeColor: Theme.of(context).primaryColor);
+          });
     }));
   }
 

--- a/app_feup/lib/view/Widgets/course_info_card.dart
+++ b/app_feup/lib/view/Widgets/course_info_card.dart
@@ -25,7 +25,7 @@ class CourseInfoCard extends GenericCard {
             ),
             Container(
               margin:
-                  const EdgeInsets.only(top: 20.0, bottom: 8.0, right: 30.0),
+                  const EdgeInsets.only(top: 20.0, bottom: 8.0, right: 20.0),
               child: getInfoText(course.currYear, context),
             )
           ]),
@@ -56,7 +56,7 @@ class CourseInfoCard extends GenericCard {
             ),
             Container(
                 margin:
-                    const EdgeInsets.only(top: 10.0, bottom: 20.0, right: 25.0),
+                    const EdgeInsets.only(top: 10.0, bottom: 20.0, right: 20.0),
                 child: getInfoText(
                     course.firstEnrollment.toString() +
                         '/' +

--- a/app_feup/lib/view/Widgets/estimated_arrival_timestamp.dart
+++ b/app_feup/lib/view/Widgets/estimated_arrival_timestamp.dart
@@ -2,7 +2,6 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:uni/model/app_state.dart';
-import 'package:uni/view/theme.dart';
 
 class EstimatedArrivalTimeStamp extends StatelessWidget {
   final String timeRemaining;
@@ -31,8 +30,6 @@ class EstimatedArrivalTimeStamp extends StatelessWidget {
     num = estimatedTime.minute;
     final String minute = (num >= 10 ? '$num' : '0$num');
 
-    return  Text('$hour:$minute',
-        style:
-            Theme.of(context).textTheme.headline4.apply(color: greyTextColor));
+    return Text('$hour:$minute', style: Theme.of(context).textTheme.headline4);
   }
 }

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -72,7 +72,7 @@ class ExamCard extends GenericCard {
         decoration: BoxDecoration(
             border: Border(
                 bottom: BorderSide(
-                    width: 1.5, color: Theme.of(context).accentColor))),
+                    width: 1.5, color: Theme.of(context).dividerColor))),
       ));
     }
     for (int i = 1; i < 4 && i < exams.length; i++) {

--- a/app_feup/lib/view/Widgets/exam_filter_form.dart
+++ b/app_feup/lib/view/Widgets/exam_filter_form.dart
@@ -76,8 +76,7 @@ class _ExamFilterFormState extends State<ExamFilterForm> {
             setState(() {
               filteredExams[key] = value;
             });
-          },
-          activeColor: Theme.of(context).primaryColor);
+          });
     }));
   }
 }

--- a/app_feup/lib/view/Widgets/exam_filter_form.dart
+++ b/app_feup/lib/view/Widgets/exam_filter_form.dart
@@ -22,24 +22,9 @@ class _ExamFilterFormState extends State<ExamFilterForm> {
           style: Theme.of(context).textTheme.headline6.apply(fontSizeDelta: 2)),
       actions: [
         TextButton(
-            child: Text('Cancelar',
-                style: Theme.of(context)
-                    .textTheme
-                    .headline4
-                    .apply(color: Theme.of(context).primaryColor)),
-            onPressed: () => Navigator.pop(context)),
-        TextButton(
-            child: Text('Confirmar',
-                style: Theme.of(context)
-                    .textTheme
-                    .headline4
-                    .apply(color: Theme.of(context).accentColor)),
-            style: TextButton.styleFrom(
-              backgroundColor: Theme.of(context).primaryColor,
-              shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10.0),
-                  side: BorderSide(color: Theme.of(context).primaryColor)),
-            ),
+            child: Text('Cancelar'), onPressed: () => Navigator.pop(context)),
+        ElevatedButton(
+            child: Text('Confirmar'),
             onPressed: () {
               StoreProvider.of<AppState>(context).dispatch(
                   setFilteredExams(widget.filteredExams, Completer()));

--- a/app_feup/lib/view/Widgets/exam_filter_form.dart
+++ b/app_feup/lib/view/Widgets/exam_filter_form.dart
@@ -18,8 +18,7 @@ class _ExamFilterFormState extends State<ExamFilterForm> {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Definições Filtro de Exames',
-          style: Theme.of(context).textTheme.headline6.apply(fontSizeDelta: 2)),
+      title: Text('Definições Filtro de Exames'),
       actions: [
         TextButton(
             child: Text('Cancelar'), onPressed: () => Navigator.pop(context)),

--- a/app_feup/lib/view/Widgets/exam_page_title_filter.dart
+++ b/app_feup/lib/view/Widgets/exam_page_title_filter.dart
@@ -20,7 +20,7 @@ class ExamPageTitleFilter extends StatelessWidget {
             style:
                 Theme.of(context).textTheme.headline6.apply(fontSizeDelta: 7),
           ),
-          Material(child: ExamFilterMenu()),
+          Row(children: [ExamFilterMenu()]),
         ],
       ),
     );

--- a/app_feup/lib/view/Widgets/exam_page_title_filter.dart
+++ b/app_feup/lib/view/Widgets/exam_page_title_filter.dart
@@ -20,7 +20,7 @@ class ExamPageTitleFilter extends StatelessWidget {
             style:
                 Theme.of(context).textTheme.headline6.apply(fontSizeDelta: 7),
           ),
-          Row(children: [ExamFilterMenu()]),
+          Material(child: ExamFilterMenu()),
         ],
       ),
     );

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -49,6 +49,9 @@ class FormTextField extends StatelessWidget {
               minLines: minLines,
               maxLines: maxLines,
               decoration: InputDecoration(
+                focusedBorder: UnderlineInputBorder(
+                  borderSide: BorderSide(color: Theme.of(context).accentColor),
+                ),
                 hintText: hintText,
                 hintStyle: Theme.of(context).textTheme.bodyText2,
                 labelText: labelText,

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -26,25 +26,25 @@ class FormTextField extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
-      margin:  EdgeInsets.only(bottom: bottomMargin),
-      child:  Column(
+    return Container(
+      margin: EdgeInsets.only(bottom: bottomMargin),
+      child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-           Text(
+          Text(
             description,
             style: Theme.of(context).textTheme.bodyText2,
             textAlign: TextAlign.left,
           ),
-           Row(children: <Widget>[
-             Container(
-                margin:  EdgeInsets.only(right: 15),
-                child:  Icon(
+          Row(children: <Widget>[
+            Container(
+                margin: EdgeInsets.only(right: 15),
+                child: Icon(
                   icon,
-                  color: Theme.of(context).primaryColor,
+                  color: Theme.of(context).accentColor,
                 )),
             Expanded(
-                child:  TextFormField(
+                child: TextFormField(
               // margins
               minLines: minLines,
               maxLines: maxLines,

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -91,8 +91,8 @@ class GenericCardState extends State<GenericCard> {
                                         fontSizeDelta: -53,
                                         fontWeightDelta: -3)),
                             alignment: Alignment.centerLeft,
-                            padding: EdgeInsets.only(left: 16),
-                            margin: EdgeInsets.only(top: 15, bottom: 11),
+                            padding: EdgeInsets.symmetric(horizontal: 15),
+                            margin: EdgeInsets.only(top: 15, bottom: 10),
                           )),
                           this.getDeleteIcon(context)
                         ].where((e) => e != null).toList(),
@@ -100,10 +100,10 @@ class GenericCardState extends State<GenericCard> {
                       ),
                       Container(
                         padding: EdgeInsets.only(
-                            left: this.padding,
-                            right: this.padding,
-                            bottom: this.padding,
-                            top: 4.0),
+                          left: this.padding,
+                          right: this.padding,
+                          bottom: this.padding,
+                        ),
                         child: widget.buildCardContent(context),
                       )
                     ],
@@ -119,7 +119,6 @@ class GenericCardState extends State<GenericCard> {
             iconSize: 22.0,
             icon: Icon(Icons.delete),
             tooltip: 'Remover',
-            color: Theme.of(context).textTheme.headline6.color,
             onPressed: widget.onDelete,
           )
         : null;

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -19,7 +19,7 @@ abstract class GenericCard extends StatefulWidget {
 
   @override
   State<StatefulWidget> createState() {
-    return  GenericCardState();
+    return GenericCardState();
   }
 
   Widget buildCardContent(BuildContext context);
@@ -35,9 +35,7 @@ abstract class GenericCard extends StatefulWidget {
     if (time == null) return Text('N/A');
     final t = DateTime.parse(time);
     return Container(
-        child: Text(
-            'última atualização às ' +
-                t.toTimeHourMinString(),
+        child: Text('última atualização às ' + t.toTimeHourMinString(),
             style: Theme.of(context).textTheme.headline2),
         alignment: Alignment.center);
   }
@@ -55,12 +53,12 @@ class GenericCardState extends State<GenericCard> {
             margin: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
             color: Color.fromARGB(0, 0, 0, 0),
             elevation: 0,
-            shape:  RoundedRectangleBorder(
-                borderRadius:  BorderRadius.circular(this.borderRadius)),
-            child:  Container(
+            shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(this.borderRadius)),
+            child: Container(
               decoration: BoxDecoration(
                   boxShadow: [
-                     BoxShadow(
+                    BoxShadow(
                         color: Color.fromARGB(0x1c, 0, 0, 0),
                         blurRadius: 7.0,
                         offset: Offset(0.0, 1.0))
@@ -68,27 +66,27 @@ class GenericCardState extends State<GenericCard> {
                   color: Theme.of(context).accentColor,
                   borderRadius:
                       BorderRadius.all(Radius.circular(this.borderRadius))),
-              child:  ConstrainedBox(
-                constraints:  BoxConstraints(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
                   minHeight: 60.0,
                 ),
-                child:  Container(
+                child: Container(
                   decoration: BoxDecoration(
                       color: Colors.white,
                       borderRadius:
                           BorderRadius.all(Radius.circular(this.borderRadius))),
                   width: (double.infinity),
-                  child:  Column(
+                  child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: <Widget>[
-                       Row(
+                      Row(
                         children: [
                           Flexible(
                               child: Container(
                             child: Text(widget.getTitle(),
                                 style: Theme.of(context)
                                     .textTheme
-                                    .headline5
+                                    .headline1
                                     .apply(
                                         fontSizeDelta: -53,
                                         fontWeightDelta: -3)),

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -36,7 +36,7 @@ abstract class GenericCard extends StatefulWidget {
     final t = DateTime.parse(time);
     return Container(
         child: Text('última atualização às ' + t.toTimeHourMinString(),
-            style: Theme.of(context).textTheme.headline2),
+            style: Theme.of(context).textTheme.caption),
         alignment: Alignment.center);
   }
 }

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -63,7 +63,7 @@ class GenericCardState extends State<GenericCard> {
                         blurRadius: 7.0,
                         offset: Offset(0.0, 1.0))
                   ],
-                  color: Theme.of(context).accentColor,
+                  color: Theme.of(context).dividerColor,
                   borderRadius:
                       BorderRadius.all(Radius.circular(this.borderRadius))),
               child: ConstrainedBox(
@@ -72,7 +72,7 @@ class GenericCardState extends State<GenericCard> {
                 ),
                 child: Container(
                   decoration: BoxDecoration(
-                      color: Colors.white,
+                      color: Theme.of(context).primaryColor,
                       borderRadius:
                           BorderRadius.all(Radius.circular(this.borderRadius))),
                   width: (double.infinity),

--- a/app_feup/lib/view/Widgets/last_update_timestamp.dart
+++ b/app_feup/lib/view/Widgets/last_update_timestamp.dart
@@ -1,5 +1,4 @@
 import 'package:uni/model/app_state.dart';
-import 'package:uni/view/theme.dart';
 import 'package:tuple/tuple.dart';
 
 import 'package:flutter/material.dart';
@@ -12,7 +11,7 @@ class LastUpdateTimeStamp extends StatelessWidget {
       converter: (store) => Tuple2(
           store.state.content['timeStamp'], store.state.content['currentTime']),
       builder: (context, timeStamps) {
-        return  Container(
+        return Container(
             padding: EdgeInsets.only(top: 8.0, bottom: 10.0),
             child: this.getContent(context, timeStamps));
       },
@@ -23,17 +22,14 @@ class LastUpdateTimeStamp extends StatelessWidget {
     final Duration lastUpdate = timeStamps.item2.difference(timeStamps.item1);
     final int lastUpdateMinutes = lastUpdate.inMinutes;
 
-    return  Row(
+    return Row(
         mainAxisSize: MainAxisSize.max,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
           Text(
               'Atualizado há $lastUpdateMinutes minuto' +
                   (lastUpdateMinutes != 1 ? 's' : ''),
-              style: Theme.of(context)
-                  .textTheme
-                  .headline4
-                  .apply(color: greyTextColor))
+              style: Theme.of(context).textTheme.headline4)
         ]);
   }
 }

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -11,7 +11,6 @@ import 'package:uni/view/Widgets/bus_stop_card.dart';
 import 'package:uni/view/Widgets/exam_card.dart';
 import 'package:uni/view/Widgets/print_info_card.dart';
 import 'package:uni/view/Widgets/schedule_card.dart';
-import 'package:uni/view/theme.dart';
 
 class MainCardsList extends StatelessWidget {
   final Map<FAVORITE_WIDGET_TYPE, Function> cardCreators = {
@@ -88,7 +87,8 @@ class MainCardsList extends StatelessWidget {
             },
           ),
           decoration: BoxDecoration(
-              border: Border(bottom: BorderSide(color: accentColor))),
+              border: Border(
+                  bottom: BorderSide(color: Theme.of(context).accentColor))),
         ));
       }
     });
@@ -194,4 +194,3 @@ class MainCardsList extends StatelessWidget {
     return result;
   }
 }
-

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -53,13 +53,7 @@ class MainCardsList extends StatelessWidget {
                 ),
                 actions: [
                   TextButton(
-                      child: Text(
-                        'Cancelar',
-                        style: Theme.of(context)
-                            .textTheme
-                            .headline4
-                            .apply(color: Theme.of(context).primaryColor),
-                      ),
+                      child: Text('Cancelar'),
                       onPressed: () => Navigator.pop(context))
                 ]);
           }), //Add FAB functionality here
@@ -88,7 +82,7 @@ class MainCardsList extends StatelessWidget {
           ),
           decoration: BoxDecoration(
               border: Border(
-                  bottom: BorderSide(color: Theme.of(context).accentColor))),
+                  bottom: BorderSide(color: Theme.of(context).dividerColor))),
         ));
       }
     });

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -122,13 +122,8 @@ class MainCardsList extends StatelessWidget {
         GestureDetector(
             onTap: () => StoreProvider.of<AppState>(context)
                 .dispatch(SetHomePageEditingMode(!this.isEditing(context))),
-            child: Text(
-              this.isEditing(context) ? 'Concluir Edição' : 'Editar',
-              style: Theme.of(context)
-                  .textTheme
-                  .subtitle2
-                  .apply(fontSizeFactor: 0.8),
-            ))
+            child: Text(this.isEditing(context) ? 'Concluir Edição' : 'Editar',
+                style: Theme.of(context).textTheme.caption))
       ]),
     );
   }

--- a/app_feup/lib/view/Widgets/navigation_drawer.dart
+++ b/app_feup/lib/view/Widgets/navigation_drawer.dart
@@ -1,4 +1,3 @@
-import 'package:uni/view/theme.dart';
 import 'package:flutter/material.dart';
 import '../../utils/constants.dart' as Constants;
 
@@ -80,7 +79,7 @@ class NavigationDrawerState extends State<NavigationDrawer> {
             style: Theme.of(context)
                 .textTheme
                 .headline6
-                .apply(color: primaryColor)),
+                .apply(color: Theme.of(context).primaryColor)),
       ),
     );
   }
@@ -94,7 +93,7 @@ class NavigationDrawerState extends State<NavigationDrawer> {
             child: Text(d,
                 style: TextStyle(
                     fontSize: 18.0,
-                    color: primaryColor,
+                    color: Theme.of(context).primaryColor,
                     fontWeight: FontWeight.normal)),
           ),
           dense: true,

--- a/app_feup/lib/view/Widgets/navigation_drawer.dart
+++ b/app_feup/lib/view/Widgets/navigation_drawer.dart
@@ -60,8 +60,8 @@ class NavigationDrawerState extends State<NavigationDrawer> {
         ? BoxDecoration(
             border: Border(
                 left: BorderSide(
-                    color: Theme.of(context).primaryColor, width: 3.0)),
-            color: Theme.of(context).accentColor,
+                    color: Theme.of(context).accentColor, width: 3.0)),
+            color: Theme.of(context).dividerColor,
           )
         : null;
   }
@@ -79,7 +79,7 @@ class NavigationDrawerState extends State<NavigationDrawer> {
             style: Theme.of(context)
                 .textTheme
                 .headline6
-                .apply(color: Theme.of(context).primaryColor)),
+                .apply(color: Theme.of(context).accentColor)),
       ),
     );
   }
@@ -93,7 +93,7 @@ class NavigationDrawerState extends State<NavigationDrawer> {
             child: Text(d,
                 style: TextStyle(
                     fontSize: 18.0,
-                    color: Theme.of(context).primaryColor,
+                    color: Theme.of(context).accentColor,
                     fontWeight: FontWeight.normal)),
           ),
           dense: true,

--- a/app_feup/lib/view/Widgets/row_container.dart
+++ b/app_feup/lib/view/Widgets/row_container.dart
@@ -9,11 +9,11 @@ class RowContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
+    return Container(
       decoration: BoxDecoration(
           border: Border.all(
               color: borderColor == null
-                  ? Theme.of(context).accentColor
+                  ? Theme.of(context).dividerColor
                   : this.borderColor,
               width: 0.5),
           color: this.color,

--- a/app_feup/lib/view/Widgets/sliver_app_bar_delegate.dart
+++ b/app_feup/lib/view/Widgets/sliver_app_bar_delegate.dart
@@ -14,15 +14,14 @@ class SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   @override
   Widget build(
       BuildContext context, double shrinkOffset, bool overlapsContent) {
-    return  Container(
+    return Container(
       decoration: const BoxDecoration(
         border: Border(
           bottom: BorderSide(width: 1.0, color: Colors.grey),
         ),
       ),
       constraints: BoxConstraints(maxHeight: 150.0),
-      child:  Material(
-        color: Colors.white,
+      child: Material(
         child: _tabBar,
       ),
     );

--- a/app_feup/lib/view/Widgets/terms_and_conditions.dart
+++ b/app_feup/lib/view/Widgets/terms_and_conditions.dart
@@ -18,18 +18,7 @@ class TermsAndConditions extends StatelessWidget {
             termsAndConditionsSaved = termsAndConditions.data;
           }
           return MarkdownBody(
-            styleSheet: MarkdownStyleSheet(
-              // Once we upgrade to the current stable version of Flutter,
-              // this should be passed through 'headline1' property in ThemeData
-              h1: Theme.of(context).textTheme.headline5.copyWith(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w400,
-                  color: Colors.black),
-              p: Theme.of(context).textTheme.headline5.copyWith(
-                  fontSize: 15,
-                  fontWeight: FontWeight.w400,
-                  color: Colors.black),
-            ),
+            styleSheet: MarkdownStyleSheet(),
             shrinkWrap: false,
             data: termsAndConditionsSaved,
             onTapLink: (text, url, title) async {

--- a/app_feup/lib/view/Widgets/toast_message.dart
+++ b/app_feup/lib/view/Widgets/toast_message.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:toast/toast.dart';
+
+class ToastMessage {
+  static display(BuildContext context, String msg) {
+    Toast.show(
+      msg,
+      context,
+      duration: Toast.LENGTH_LONG,
+      gravity: Toast.BOTTOM,
+      backgroundColor: Theme.of(context).dialogBackgroundColor,
+      backgroundRadius: 16.0,
+      textColor: Theme.of(context).textTheme.headline1.color,
+    );
+  }
+}

--- a/app_feup/lib/view/Widgets/toast_message.dart
+++ b/app_feup/lib/view/Widgets/toast_message.dart
@@ -2,15 +2,16 @@ import 'package:flutter/material.dart';
 import 'package:toast/toast.dart';
 
 class ToastMessage {
+  static const Color toastColor = Color.fromARGB(255, 100, 100, 100);
   static display(BuildContext context, String msg) {
     Toast.show(
       msg,
       context,
       duration: Toast.LENGTH_LONG,
       gravity: Toast.BOTTOM,
-      backgroundColor: Theme.of(context).dialogBackgroundColor,
+      backgroundColor: toastColor,
       backgroundRadius: 16.0,
-      textColor: Theme.of(context).textTheme.headline1.color,
+      textColor: Colors.white,
     );
   }
 }

--- a/app_feup/lib/view/Widgets/trip_row.dart
+++ b/app_feup/lib/view/Widgets/trip_row.dart
@@ -1,7 +1,6 @@
 import 'package:uni/model/entities/trip.dart';
 import 'package:flutter/material.dart';
 import 'package:uni/view/Widgets/estimated_arrival_timestamp.dart';
-import '../theme.dart';
 
 class TripRow extends StatelessWidget {
   final Trip trip;
@@ -13,10 +12,10 @@ class TripRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  Row(
+    return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: <Widget>[
-         Column(
+        Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Text(this.trip.line,
@@ -25,25 +24,20 @@ class TripRow extends StatelessWidget {
                 style: Theme.of(context)
                     .textTheme
                     .headline4
-                    .apply(color: lightGreyTextColor, fontWeightDelta: 2)),
+                    .apply(fontWeightDelta: 2)),
             Text(this.trip.destination,
-                style: Theme.of(context)
-                    .textTheme
-                    .headline4
-                    .apply(color: greyTextColor)),
+                style: Theme.of(context).textTheme.headline4),
           ],
         ),
-         Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: <Widget>[
-              Text(this.trip.timeRemaining.toString() + '\'',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(color: lightGreyTextColor, fontWeightDelta: 2)),
-               EstimatedArrivalTimeStamp(
-                  timeRemaining: this.trip.timeRemaining.toString()),
-            ])
+        Column(crossAxisAlignment: CrossAxisAlignment.end, children: <Widget>[
+          Text(this.trip.timeRemaining.toString() + '\'',
+              style: Theme.of(context)
+                  .textTheme
+                  .headline4
+                  .apply(fontWeightDelta: 2)),
+          EstimatedArrivalTimeStamp(
+              timeRemaining: this.trip.timeRemaining.toString()),
+        ])
       ],
     );
   }

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -1,45 +1,35 @@
 import 'package:flutter/material.dart';
 
-//fff9f9f9
-const Color primaryColor = Color.fromARGB(255, 0x75, 0x17, 0x1e);
-const Color tonedDownPrimary = Color.fromARGB(255, 190, 40, 40);
-const Color subtitleColor = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
-const Color accentColor = Color.fromARGB(255, 215, 215, 215);
-const Color darkGreyColor = Color.fromARGB(255, 210, 210, 210);
-const Color greyTextColor = Color.fromARGB(255, 0x46, 0x46, 0x46);
-const Color whiteTextColor = Color.fromARGB(255, 255, 255, 255);
-const Color bodyTitle = Color.fromARGB(255, 131, 131, 131);
-const Color greyBorder = Color.fromARGB(64, 0x46, 0x46, 0x46);
-const Color backgroundColor = Color.fromARGB(255, 0xfa, 0xfa, 0xfa);
-const Color toastColor = Color.fromARGB(255, 100, 100, 100);
-const Color lightGreyTextColor = Color.fromARGB(255, 90, 90, 90);
-
-const Color divider = Color.fromARGB(255, 180, 180, 180);
-const Color hintColor = Colors.white;
+const Color _darkRed = Color.fromARGB(255, 0x75, 0x17, 0x1e);
+const Color _lightRed = Color.fromARGB(255, 190, 40, 40);
+const Color _mildWhite = Color.fromARGB(255, 0xfa, 0xfa, 0xfa);
+const Color _lightGrey = Color.fromARGB(255, 215, 215, 215);
+const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
+const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
+const Color _mildBlack = Color.fromARGB(255, 0x46, 0x46, 0x46);
 
 ThemeData applicationLightTheme = ThemeData(
     brightness: Brightness.light,
-    primaryColor: primaryColor,
-    accentColor: accentColor,
-    hintColor: hintColor,
-    backgroundColor: backgroundColor,
-    dialogBackgroundColor: toastColor,
+    primaryColor: _darkRed,
+    accentColor: _lightGrey,
+    hintColor: Colors.white,
+    backgroundColor: _mildWhite,
     textTheme: TextTheme(
       headline6: TextStyle(
-          fontSize: 17.0, color: greyTextColor, fontWeight: FontWeight.w300),
+          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
       headline5: TextStyle(
-          fontSize: 72.0, fontWeight: FontWeight.bold, color: primaryColor),
-      subtitle2: TextStyle(
-          fontSize: 17.0, color: subtitleColor, fontWeight: FontWeight.w300),
+          fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
+      subtitle2:
+          TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
       headline4: TextStyle(
-          fontSize: 17.0, color: greyTextColor, fontWeight: FontWeight.w300),
+          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
       headline3: TextStyle(
-          fontSize: 17.0, color: tonedDownPrimary, fontWeight: FontWeight.w300),
+          fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
       headline2: TextStyle(
-          fontSize: 10.0, color: greyTextColor, fontWeight: FontWeight.w500),
+          fontSize: 10.0, color: _mildBlack, fontWeight: FontWeight.w500),
       headline1: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w200),
-      bodyText2: TextStyle(fontSize: 15.0, color: primaryColor),
-      bodyText1: TextStyle(fontSize: 17.0, color: primaryColor),
+          fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
+      bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
+      bodyText1: TextStyle(fontSize: 17.0, color: _darkRed),
     ),
-    primaryIconTheme: IconThemeData(color: primaryColor));
+    iconTheme: IconThemeData(color: _strongGrey));

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -20,7 +20,7 @@ ThemeData applicationLightTheme = ThemeData(
     headline1:
         TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
     headline2: TextStyle(
-        fontSize: 10.0, color: _mildBlack, fontWeight: FontWeight.w500),
+        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
     headline3: TextStyle(
         fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
     headline4: TextStyle(
@@ -29,10 +29,13 @@ ThemeData applicationLightTheme = ThemeData(
         TextStyle(fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
     headline6: TextStyle(
         fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-    subtitle2:
+    subtitle1:
         TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
+    subtitle2:
+        TextStyle(fontSize: 16.0, color: _grey, fontWeight: FontWeight.w300),
     bodyText1: TextStyle(fontSize: 15.0, color: _darkRed),
     bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
+    caption: TextStyle(fontSize: 12.0, color: _grey),
   ),
   iconTheme: IconThemeData(color: _strongGrey),
   unselectedWidgetColor: _strongGrey,

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -6,7 +6,7 @@ const Color _mildWhite = Color.fromARGB(255, 0xfa, 0xfa, 0xfa);
 const Color _lightGrey = Color.fromARGB(255, 215, 215, 215);
 const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
 const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
-const Color _mildBlack = Color.fromARGB(255, 0x46, 0x46, 0x46);
+const Color _mildBlack = Color.fromARGB(255, 0x30, 0x30, 0x30);
 
 ThemeData applicationLightTheme = ThemeData(
   brightness: Brightness.light,
@@ -25,17 +25,18 @@ ThemeData applicationLightTheme = ThemeData(
         fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
     headline4: TextStyle(
         fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-    headline5:
-        TextStyle(fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
-    headline6: TextStyle(
+    headline5: TextStyle(
         fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w400),
+    headline6: TextStyle(
+        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
     subtitle1:
         TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
     subtitle2:
         TextStyle(fontSize: 16.0, color: _grey, fontWeight: FontWeight.w300),
-    bodyText1: TextStyle(fontSize: 15.0, color: _darkRed),
-    bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
-    caption: TextStyle(fontSize: 12.0, color: _grey),
+    bodyText1: TextStyle(fontSize: 16.0, color: _mildBlack),
+    bodyText2: TextStyle(fontSize: 15.0, color: _mildBlack),
+    caption:
+        TextStyle(fontSize: 12.0, color: _grey, fontWeight: FontWeight.w500),
   ),
   iconTheme: IconThemeData(color: _strongGrey),
   unselectedWidgetColor: _grey,

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -10,10 +10,12 @@ const Color _mildBlack = Color.fromARGB(255, 0x46, 0x46, 0x46);
 
 ThemeData applicationLightTheme = ThemeData(
   brightness: Brightness.light,
-  primaryColor: _darkRed,
-  accentColor: _lightGrey,
+  primaryColor: Colors.white,
+  accentColor: _darkRed,
+  dividerColor: _lightGrey,
   hintColor: _grey,
   backgroundColor: _mildWhite,
+  scaffoldBackgroundColor: _mildWhite,
   textTheme: TextTheme(
     headline6: TextStyle(
         fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
@@ -49,6 +51,10 @@ ThemeData applicationLightTheme = ThemeData(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12.0),
         ),
-        textStyle: TextStyle(fontWeight: FontWeight.w400)),
+        textStyle: TextStyle(fontWeight: FontWeight.w400, fontSize: 15.0)),
   ),
+  textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+          primary: _darkRed,
+          textStyle: TextStyle(fontSize: 15.0, fontWeight: FontWeight.w400))),
 );

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -17,30 +17,29 @@ const Color lightGreyTextColor = Color.fromARGB(255, 90, 90, 90);
 const Color divider = Color.fromARGB(255, 180, 180, 180);
 const Color hintColor = Colors.white;
 
-ThemeData applicationTheme = ThemeData(
-  brightness: Brightness.light,
-  primaryColor: primaryColor,
-  accentColor: accentColor,
-  hintColor: hintColor,
-  backgroundColor: backgroundColor,
-
-//  fontFamily: 'Raleway',
-
-  textTheme: TextTheme(
-    headline5: TextStyle(
-        fontSize: 72.0, fontWeight: FontWeight.bold, color: primaryColor),
-    headline6: TextStyle(
-        fontSize: 17.0, color: greyTextColor, fontWeight: FontWeight.w300),
-    bodyText2: TextStyle(fontSize: 15.0, color: primaryColor),
-    subtitle2: TextStyle(
-        fontSize: 17.0, color: subtitleColor, fontWeight: FontWeight.w300),
-    headline4: TextStyle(
-        fontSize: 17.0, color: greyTextColor, fontWeight: FontWeight.w300),
-    headline3: TextStyle(
-        fontSize: 17.0, color: tonedDownPrimary, fontWeight: FontWeight.w300),
-    headline2: TextStyle(
-        fontSize: 10.0, color: greyTextColor, fontWeight: FontWeight.w500),
-    headline1: TextStyle(
-        fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w200),
-  ),
-);
+ThemeData applicationLightTheme = ThemeData(
+    brightness: Brightness.light,
+    primaryColor: primaryColor,
+    accentColor: accentColor,
+    hintColor: hintColor,
+    backgroundColor: backgroundColor,
+    dialogBackgroundColor: toastColor,
+    textTheme: TextTheme(
+      headline6: TextStyle(
+          fontSize: 17.0, color: greyTextColor, fontWeight: FontWeight.w300),
+      headline5: TextStyle(
+          fontSize: 72.0, fontWeight: FontWeight.bold, color: primaryColor),
+      subtitle2: TextStyle(
+          fontSize: 17.0, color: subtitleColor, fontWeight: FontWeight.w300),
+      headline4: TextStyle(
+          fontSize: 17.0, color: greyTextColor, fontWeight: FontWeight.w300),
+      headline3: TextStyle(
+          fontSize: 17.0, color: tonedDownPrimary, fontWeight: FontWeight.w300),
+      headline2: TextStyle(
+          fontSize: 10.0, color: greyTextColor, fontWeight: FontWeight.w500),
+      headline1: TextStyle(
+          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w200),
+      bodyText2: TextStyle(fontSize: 15.0, color: primaryColor),
+      bodyText1: TextStyle(fontSize: 17.0, color: primaryColor),
+    ),
+    primaryIconTheme: IconThemeData(color: primaryColor));

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -9,27 +9,46 @@ const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
 const Color _mildBlack = Color.fromARGB(255, 0x46, 0x46, 0x46);
 
 ThemeData applicationLightTheme = ThemeData(
-    brightness: Brightness.light,
-    primaryColor: _darkRed,
-    accentColor: _lightGrey,
-    hintColor: Colors.white,
-    backgroundColor: _mildWhite,
-    textTheme: TextTheme(
-      headline6: TextStyle(
-          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-      headline5: TextStyle(
-          fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
-      subtitle2:
-          TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
-      headline4: TextStyle(
-          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-      headline3: TextStyle(
-          fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
-      headline2: TextStyle(
-          fontSize: 10.0, color: _mildBlack, fontWeight: FontWeight.w500),
-      headline1: TextStyle(
-          fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
-      bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
-      bodyText1: TextStyle(fontSize: 17.0, color: _darkRed),
-    ),
-    iconTheme: IconThemeData(color: _strongGrey));
+  brightness: Brightness.light,
+  primaryColor: _darkRed,
+  accentColor: _lightGrey,
+  hintColor: _grey,
+  backgroundColor: _mildWhite,
+  textTheme: TextTheme(
+    headline6: TextStyle(
+        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
+    headline5:
+        TextStyle(fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
+    subtitle2:
+        TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
+    headline4: TextStyle(
+        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
+    headline3: TextStyle(
+        fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
+    headline2: TextStyle(
+        fontSize: 10.0, color: _mildBlack, fontWeight: FontWeight.w500),
+    headline1:
+        TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
+    bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
+    bodyText1: TextStyle(fontSize: 15.0, color: _darkRed),
+  ),
+  iconTheme: IconThemeData(color: _strongGrey),
+  unselectedWidgetColor: _strongGrey,
+  toggleableActiveColor: _darkRed,
+  tabBarTheme: TabBarTheme(
+    unselectedLabelColor: _strongGrey,
+    labelColor: _strongGrey,
+    labelPadding: EdgeInsets.all(0.0),
+  ),
+  canvasColor: Colors.white,
+  cardColor: Colors.white,
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ElevatedButton.styleFrom(
+        primary: _darkRed,
+        padding: const EdgeInsets.all(10.0),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        textStyle: TextStyle(fontWeight: FontWeight.w400)),
+  ),
+);

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -28,7 +28,7 @@ ThemeData applicationLightTheme = ThemeData(
     headline5:
         TextStyle(fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
     headline6: TextStyle(
-        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
+        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w400),
     subtitle1:
         TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
     subtitle2:
@@ -38,14 +38,14 @@ ThemeData applicationLightTheme = ThemeData(
     caption: TextStyle(fontSize: 12.0, color: _grey),
   ),
   iconTheme: IconThemeData(color: _strongGrey),
-  unselectedWidgetColor: _strongGrey,
+  unselectedWidgetColor: _grey,
   toggleableActiveColor: _darkRed,
   tabBarTheme: TabBarTheme(
     unselectedLabelColor: _strongGrey,
     labelColor: _strongGrey,
     labelPadding: EdgeInsets.all(0.0),
   ),
-  canvasColor: Colors.white,
+  canvasColor: _mildWhite,
   cardColor: Colors.white,
   elevatedButtonTheme: ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -13,26 +13,26 @@ ThemeData applicationLightTheme = ThemeData(
   primaryColor: Colors.white,
   accentColor: _darkRed,
   dividerColor: _lightGrey,
-  hintColor: _grey,
+  hintColor: _lightGrey,
   backgroundColor: _mildWhite,
   scaffoldBackgroundColor: _mildWhite,
   textTheme: TextTheme(
-    headline6: TextStyle(
+    headline1:
+        TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
+    headline2: TextStyle(
+        fontSize: 10.0, color: _mildBlack, fontWeight: FontWeight.w500),
+    headline3: TextStyle(
+        fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
+    headline4: TextStyle(
         fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
     headline5:
         TextStyle(fontSize: 17.0, color: _darkRed, fontWeight: FontWeight.w400),
+    headline6: TextStyle(
+        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
     subtitle2:
         TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
-    headline4: TextStyle(
-        fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-    headline3: TextStyle(
-        fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
-    headline2: TextStyle(
-        fontSize: 10.0, color: _mildBlack, fontWeight: FontWeight.w500),
-    headline1:
-        TextStyle(fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
-    bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
     bodyText1: TextStyle(fontSize: 15.0, color: _darkRed),
+    bodyText2: TextStyle(fontSize: 15.0, color: _darkRed),
   ),
   iconTheme: IconThemeData(color: _strongGrey),
   unselectedWidgetColor: _strongGrey,

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.1+20
+version: 1.1.1+21
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/app_feup/test/integration/src/exams_page_test.dart
+++ b/app_feup/test/integration/src/exams_page_test.dart
@@ -151,8 +151,11 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      final ElevatedButton okButton =
-          find.byType(ElevatedButton).evaluate().first.widget;
+      final ElevatedButton okButton = find
+          .widgetWithText(ElevatedButton, 'Confirmar')
+          .evaluate()
+          .first
+          .widget;
       expect(find.byWidget(okButton), findsOneWidget);
 
       okButton.onPressed();

--- a/app_feup/test/integration/src/exams_page_test.dart
+++ b/app_feup/test/integration/src/exams_page_test.dart
@@ -151,8 +151,8 @@ void main() {
 
       await tester.pumpAndSettle();
 
-      final TextButton okButton =
-          find.widgetWithText(TextButton, 'Confirmar').evaluate().first.widget;
+      final ElevatedButton okButton =
+          find.byType(ElevatedButton).evaluate().first.widget;
       expect(find.byWidget(okButton), findsOneWidget);
 
       okButton.onPressed();


### PR DESCRIPTION
Refactors the app theming before we go ahead and work on #329 and #244.
Old unused colors were ditched and very similar colors were merged.
We were using `accentColor` as a backgroundColor and `primaryColor` as the accent, so that was swapped.
All color variables were made private so that all widgets rely on theme properties.
Theme properties were added as much as possible so that widgets with common style such as `TextButton`, `TabBar` or `ElevatedButton` are easily maintainable.
This should have little effect visually. Also, if you feel some color needs to return, please let me know.

# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [ ] Clean, well structured code
