### PR TITLE
Adding color tagging feature in Exams Page

### DIFF
--- a/app_feup/lib/controller/exam.dart
+++ b/app_feup/lib/controller/exam.dart
@@ -1,0 +1,6 @@
+import 'package:uni/model/entities/exam.dart';
+
+bool isHighlighted(Exam exam) {
+  return (exam.examType.contains('''EN''')) ||
+      (exam.examType.contains('''MT'''));
+}

--- a/app_feup/lib/view/Pages/exams_page_view.dart
+++ b/app_feup/lib/view/Pages/exams_page_view.dart
@@ -120,7 +120,9 @@ class ExamsList extends StatelessWidget {
         key: Key(keyValue),
         margin: EdgeInsets.fromLTRB(12, 4, 12, 0),
         child: RowContainer(
-            color: examColor(exam, context),
+            color: isHighlighted(exam, context)
+                ? Theme.of(context).hintColor
+                : Theme.of(context).backgroundColor,
             child: ScheduleRow(
                 subject: exam.subject,
                 rooms: exam.rooms,

--- a/app_feup/lib/view/Pages/exams_page_view.dart
+++ b/app_feup/lib/view/Pages/exams_page_view.dart
@@ -1,9 +1,9 @@
+import 'package:uni/controller/exam.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/exam.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:uni/view/Pages/secondary_page_view.dart';
-import 'package:uni/view/Widgets/exam_card.dart';
 import 'package:uni/view/Widgets/exam_page_title_filter.dart';
 import 'package:uni/view/Widgets/row_container.dart';
 import 'package:uni/view/Widgets/schedule_row.dart';

--- a/app_feup/lib/view/Pages/exams_page_view.dart
+++ b/app_feup/lib/view/Pages/exams_page_view.dart
@@ -3,6 +3,7 @@ import 'package:uni/model/entities/exam.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:uni/view/Pages/secondary_page_view.dart';
+import 'package:uni/view/Widgets/exam_card.dart';
 import 'package:uni/view/Widgets/exam_page_title_filter.dart';
 import 'package:uni/view/Widgets/row_container.dart';
 import 'package:uni/view/Widgets/schedule_row.dart';
@@ -119,6 +120,7 @@ class ExamsList extends StatelessWidget {
         key: Key(keyValue),
         margin: EdgeInsets.fromLTRB(12, 4, 12, 0),
         child: RowContainer(
+            color: examColor(exam, context),
             child: ScheduleRow(
                 subject: exam.subject,
                 rooms: exam.rooms,

--- a/app_feup/lib/view/Pages/exams_page_view.dart
+++ b/app_feup/lib/view/Pages/exams_page_view.dart
@@ -120,7 +120,7 @@ class ExamsList extends StatelessWidget {
         key: Key(keyValue),
         margin: EdgeInsets.fromLTRB(12, 4, 12, 0),
         child: RowContainer(
-            color: isHighlighted(exam, context)
+            color: isHighlighted(exam)
                 ? Theme.of(context).hintColor
                 : Theme.of(context).backgroundColor,
             child: ScheduleRow(

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -1,3 +1,4 @@
+import 'package:uni/controller/exam.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/exam.dart';
 import 'package:flutter/cupertino.dart';
@@ -12,11 +13,6 @@ import 'package:uni/view/Widgets/schedule_event_rectangle.dart';
 import 'package:uni/view/Widgets/schedule_row.dart';
 
 import 'generic_card.dart';
-
-bool isHighlighted(Exam exam) {
-  return (exam.examType.contains('''EN''')) ||
-          (exam.examType.contains('''MT'''));
-}
 
 class ExamCard extends GenericCard {
   ExamCard({Key key}) : super(key: key);

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -13,11 +13,11 @@ import 'package:uni/view/Widgets/schedule_row.dart';
 
 import 'generic_card.dart';
 
-Color examColor(Exam exam, context) {
+bool isHighlighted(Exam exam, context) {
   return (exam.examType.contains('''EN''')) ||
           (exam.examType.contains('''MT'''))
-      ? Theme.of(context).hintColor
-      : Theme.of(context).backgroundColor;
+      ? true
+      : false;
 }
 
 class ExamCard extends GenericCard {
@@ -92,7 +92,9 @@ class ExamCard extends GenericCard {
       DateRectangle(date: exam.weekDay + ', ' + exam.day + ' de ' + exam.month),
       Container(
         child: RowContainer(
-          color: examColor(exam, context),
+          color: isHighlighted(exam, context)
+              ? Theme.of(context).backgroundColor
+              : Theme.of(context).hintColor,
           child: ScheduleRow(
             subject: exam.subject,
             rooms: exam.rooms,
@@ -109,7 +111,9 @@ class ExamCard extends GenericCard {
     return Container(
       margin: EdgeInsets.only(top: 8),
       child: RowContainer(
-        color: examColor(exam, context),
+        color: isHighlighted(exam, context)
+            ? Theme.of(context).backgroundColor
+            : Theme.of(context).hintColor,
         child: Container(
           padding: EdgeInsets.all(11),
           child: Row(

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -13,11 +13,9 @@ import 'package:uni/view/Widgets/schedule_row.dart';
 
 import 'generic_card.dart';
 
-bool isHighlighted(Exam exam, context) {
+bool isHighlighted(Exam exam) {
   return (exam.examType.contains('''EN''')) ||
-          (exam.examType.contains('''MT'''))
-      ? true
-      : false;
+          (exam.examType.contains('''MT'''));
 }
 
 class ExamCard extends GenericCard {
@@ -92,7 +90,7 @@ class ExamCard extends GenericCard {
       DateRectangle(date: exam.weekDay + ', ' + exam.day + ' de ' + exam.month),
       Container(
         child: RowContainer(
-          color: isHighlighted(exam, context)
+          color: isHighlighted(exam)
               ? Theme.of(context).backgroundColor
               : Theme.of(context).hintColor,
           child: ScheduleRow(
@@ -111,7 +109,7 @@ class ExamCard extends GenericCard {
     return Container(
       margin: EdgeInsets.only(top: 8),
       child: RowContainer(
-        color: isHighlighted(exam, context)
+        color: isHighlighted(exam)
             ? Theme.of(context).backgroundColor
             : Theme.of(context).hintColor,
         child: Container(

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.0.0+17
+version: 1.0.0+18
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.0.0+18
+version: 1.1.0+1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #344
As in the main page, in the exam section, there is a color tag for the different kinds of exams, it was applied the same method to the exams in **exams page**. Here are some screenshots of how both pages look.

**Main Page**
<img src="https://user-images.githubusercontent.com/76732179/114551419-46e06480-9c5b-11eb-93c5-a7d0172adb7a.jpeg" width="300" >

**Exams Page**
<img src="https://user-images.githubusercontent.com/76732179/114551420-46e06480-9c5b-11eb-85af-71cbf776f87a.jpeg" width="300" >

# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [ ] Clean, well structured code
