### PR TITLE
Fix lecture constructor

### DIFF
--- a/app_feup/lib/controller/local_storage/app_lectures_database.dart
+++ b/app_feup/lib/controller/local_storage/app_lectures_database.dart
@@ -33,7 +33,7 @@ class AppLecturesDatabase extends AppDatabase {
 
     // Convert the List<Map<String, dynamic> into a List<Dog>.
     return List.generate(maps.length, (i) {
-      return Lecture.secConstructor(
+      return Lecture.fromHtml(
         maps[i]['subject'],
         maps[i]['typeClass'],
         maps[i]['day'],

--- a/app_feup/lib/controller/parsers/parser_schedule.dart
+++ b/app_feup/lib/controller/parsers/parser_schedule.dart
@@ -1,6 +1,7 @@
-import 'package:uni/model/entities/lecture.dart';
-import 'package:http/http.dart' as http;
 import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+import 'package:uni/model/entities/lecture.dart';
 
 Future<List<Lecture>> parseSchedule(http.Response response) async {
   final Set<Lecture> lectures = Set();
@@ -20,7 +21,7 @@ Future<List<Lecture>> parseSchedule(http.Response response) async {
     final String teacher = lecture['doc_sigla'];
     final String classNumber = lecture['turma_sigla'];
 
-    lectures.add(Lecture(
+    lectures.add(Lecture.fromApi(
         subject, typeClass, day, secBegin, blocks, room, teacher, classNumber));
   }
 

--- a/app_feup/lib/controller/parsers/parser_schedule_html.dart
+++ b/app_feup/lib/controller/parsers/parser_schedule_html.dart
@@ -42,7 +42,7 @@ Future<List<Lecture>> getScheduleFromHtml(http.Response response) async {
 
           semana[day] += blocks;
 
-          final Lecture lect = Lecture.secConstructor(subject, typeClass, day,
+          final Lecture lect = Lecture.fromHtml(subject, typeClass, day,
               startTime, blocks, room, teacher, classNumber);
           lecturesList.add(lect);
         }

--- a/app_feup/lib/model/entities/lecture.dart
+++ b/app_feup/lib/model/entities/lecture.dart
@@ -34,11 +34,11 @@ class Lecture {
     this.classNumber = classNumber;
 
     this.startTime = (startTimeSeconds ~/ 3600).toString().padLeft(2, '0') +
-        ':' +
+        'h' +
         ((startTimeSeconds % 3600) ~/ 60).toString().padLeft(2, '0');
     startTimeSeconds += 60 * 30 * blocks;
     this.endTime = (startTimeSeconds ~/ 3600).toString().padLeft(2, '0') +
-        ':' +
+        'h' +
         ((startTimeSeconds % 3600) ~/ 60).toString().padLeft(2, '0');
   }
 

--- a/app_feup/lib/model/entities/lecture.dart
+++ b/app_feup/lib/model/entities/lecture.dart
@@ -22,27 +22,64 @@ class Lecture {
   int blocks;
   int startTimeSeconds;
 
-  Lecture(String subject, String typeClass, int day, int startTimeSeconds,
-      int blocks, String room, String teacher, String classNumber) {
+  Lecture(
+      String subject,
+      String typeClass,
+      int day,
+      int blocks,
+      String room,
+      String teacher,
+      String classNumber,
+      int startTimeHours,
+      int startTimeMinutes,
+      int endTimeHours,
+      int endTimeMinutes) {
     this.subject = subject;
     this.typeClass = typeClass;
     this.room = room;
     this.teacher = teacher;
     this.day = day;
     this.blocks = blocks;
-    this.startTimeSeconds = startTimeSeconds;
     this.classNumber = classNumber;
-
-    this.startTime = (startTimeSeconds ~/ 3600).toString().padLeft(2, '0') +
+    this.startTime = startTimeHours.toString().padLeft(2, '0') +
         'h' +
-        ((startTimeSeconds % 3600) ~/ 60).toString().padLeft(2, '0');
-    startTimeSeconds += 60 * 30 * blocks;
-    this.endTime = (startTimeSeconds ~/ 3600).toString().padLeft(2, '0') +
+        startTimeMinutes.toString().padLeft(2, '0');
+    this.endTime = endTimeHours.toString().padLeft(2, '0') +
         'h' +
-        ((startTimeSeconds % 3600) ~/ 60).toString().padLeft(2, '0');
+        endTimeMinutes.toString().padLeft(2, '0');
   }
 
-  Lecture.secConstructor(
+  factory Lecture.fromApi(
+      String subject,
+      String typeClass,
+      int day,
+      int startTimeSeconds,
+      int blocks,
+      String room,
+      String teacher,
+      String classNumber) {
+    final startTimeHours = (startTimeSeconds ~/ 3600);
+    final startTimeMinutes = ((startTimeSeconds % 3600) ~/ 60);
+    final endTimeSeconds = 60 * 30 * blocks;
+    final endTimeHours = (endTimeSeconds ~/ 3600);
+    final endTimeMinutes = ((endTimeSeconds % 3600) ~/ 60);
+    final lecture = Lecture(
+        subject,
+        typeClass,
+        day,
+        blocks,
+        room,
+        teacher,
+        classNumber,
+        startTimeHours,
+        startTimeMinutes,
+        endTimeHours,
+        endTimeMinutes);
+    lecture.startTimeSeconds = startTimeSeconds;
+    return lecture;
+  }
+
+  factory Lecture.fromHtml(
       String subject,
       String typeClass,
       int day,
@@ -51,33 +88,30 @@ class Lecture {
       String room,
       String teacher,
       String classNumber) {
-    this.subject = subject;
-    this.typeClass = typeClass;
-    this.room = room;
-    this.teacher = teacher;
-    this.day = day;
-    this.blocks = blocks;
-    this.classNumber = classNumber;
-
-    int hour = int.parse(startTime.substring(0, 2));
-    int min = int.parse(startTime.substring(3, 5));
-    this.startTime =
-        hour.toString().padLeft(2, '0') + 'h' + min.toString().padLeft(2, '0');
-    min += blocks * 30;
-    hour += min ~/ 60;
-    min %= 60;
-    this.endTime =
-        hour.toString().padLeft(2, '0') + 'h' + min.toString().padLeft(2, '0');
+    final startTimeHours = int.parse(startTime.substring(0, 2));
+    final startTimeMinutes = int.parse(startTime.substring(3, 5));
+    final endTimeHours =
+        (startTimeMinutes + (blocks * 30)) ~/ 60 + startTimeHours;
+    final endTimeMinutes = (startTimeMinutes + (blocks * 30)) % 60;
+    return Lecture(subject, typeClass, day, blocks, room, teacher, classNumber,
+        startTimeHours, startTimeMinutes, endTimeHours, endTimeMinutes);
   }
 
   static Lecture clone(Lecture lec) {
-    return Lecture(lec.subject, lec.typeClass, lec.day, lec.startTimeSeconds,
-        lec.blocks, lec.room, lec.teacher, lec.classNumber);
+    return Lecture.fromApi(
+        lec.subject,
+        lec.typeClass,
+        lec.day,
+        lec.startTimeSeconds,
+        lec.blocks,
+        lec.room,
+        lec.teacher,
+        lec.classNumber);
   }
 
   static Lecture cloneHtml(Lecture lec) {
-    return Lecture.secConstructor(lec.subject, lec.typeClass, lec.day,
-        lec.startTime, lec.blocks, lec.room, lec.teacher, lec.classNumber);
+    return Lecture.fromHtml(lec.subject, lec.typeClass, lec.day, lec.startTime,
+        lec.blocks, lec.room, lec.teacher, lec.classNumber);
   }
 
   Map<String, dynamic> toMap() {

--- a/app_feup/test/unit/redux/schedule_action_creators_test.dart
+++ b/app_feup/test/unit/redux/schedule_action_creators_test.dart
@@ -32,7 +32,7 @@ void main() {
     final teacher1 = 'JAS';
     final day1 = 0;
     final classNumber = 'MIEIC03';
-    final lecture1 = Lecture.secConstructor(subject1, typeClass1, day1,
+    final lecture1 = Lecture.fromHtml(subject1, typeClass1, day1,
         startTime1, blocks, room1, teacher1, classNumber);
     final subject2 = 'SDIS';
     final startTime2 = '13:00';
@@ -40,7 +40,7 @@ void main() {
     final typeClass2 = 'T';
     final teacher2 = 'PMMS';
     final day2 = 0;
-    final lecture2 = Lecture.secConstructor(subject2, typeClass2, day2,
+    final lecture2 = Lecture.fromHtml(subject2, typeClass2, day2,
         startTime2, blocks, room2, teacher2, classNumber);
 
     when(mockStore.state).thenReturn(AppState(content));

--- a/app_feup/test/unit/view/Pages/schedule_page_view_test.dart
+++ b/app_feup/test/unit/view/Pages/schedule_page_view_test.dart
@@ -17,7 +17,7 @@ void main() {
     final teacher1 = 'JAS';
     final day1 = 0;
     final classNumber = 'MIEIC03';
-    final lecture1 = Lecture.secConstructor(subject1, typeClass1, day1,
+    final lecture1 = Lecture.fromHtml(subject1, typeClass1, day1,
         startTime1, blocks, room1, teacher1, classNumber);
     final subject2 = 'SDIS';
     final startTime2 = '13:00';
@@ -25,7 +25,7 @@ void main() {
     final typeClass2 = 'T';
     final teacher2 = 'PMMS';
     final day2 = 0;
-    final lecture2 = Lecture.secConstructor(subject2, typeClass2, day2,
+    final lecture2 = Lecture.fromHtml(subject2, typeClass2, day2,
         startTime2, blocks, room2, teacher2, classNumber);
     final subject3 = 'AMAT';
     final startTime3 = '12:00';
@@ -33,7 +33,7 @@ void main() {
     final typeClass3 = 'T';
     final teacher3 = 'PMMS';
     final day3 = 1;
-    final lecture3 = Lecture.secConstructor(subject3, typeClass3, day3,
+    final lecture3 = Lecture.fromHtml(subject3, typeClass3, day3,
         startTime3, blocks, room3, teacher3, classNumber);
     final subject4 = 'PROG';
     final startTime4 = '10:00';
@@ -41,7 +41,7 @@ void main() {
     final typeClass4 = 'T';
     final teacher4 = 'JAS';
     final day4 = 2;
-    final lecture4 = Lecture.secConstructor(subject4, typeClass4, day4,
+    final lecture4 = Lecture.fromHtml(subject4, typeClass4, day4,
         startTime4, blocks, room4, teacher4, classNumber);
     final subject5 = 'PPIN';
     final startTime5 = '14:00';
@@ -49,7 +49,7 @@ void main() {
     final typeClass5 = 'T';
     final teacher5 = 'SSN';
     final day5 = 3;
-    final lecture5 = Lecture.secConstructor(subject5, typeClass5, day5,
+    final lecture5 = Lecture.fromHtml(subject5, typeClass5, day5,
         startTime5, blocks, room5, teacher5, classNumber);
     final subject6 = 'SDIS';
     final startTime6 = '15:00';
@@ -57,7 +57,7 @@ void main() {
     final typeClass6 = 'T';
     final teacher6 = 'PMMS';
     final day6 = 4;
-    final lecture6 = Lecture.secConstructor(subject6, typeClass6, day6,
+    final lecture6 = Lecture.fromHtml(subject6, typeClass6, day6,
         startTime6, blocks, room6, teacher6, classNumber);
 
     final List<String> daysOfTheWeek = [

--- a/app_feup/test/unit/view/Widgets/schedule_slot_test.dart
+++ b/app_feup/test/unit/view/Widgets/schedule_slot_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 //import 'package:flutter/material.dart';
 
@@ -8,7 +9,6 @@ import '../../../testable_widget.dart';
 // https://github.com/NIAEFEUP/project-schrodinger/issues/354
 void testScheduleSlot(String subject, String begin, String end, String rooms,
     String typeClass, String teacher) {
-  /*
   final scheduleSlotTimeKey = 'schedule-slot-time-$begin-$end';
   expect(
       find.descendant(
@@ -33,7 +33,6 @@ void testScheduleSlot(String subject, String begin, String end, String rooms,
           of: find.byKey(Key(scheduleSlotTimeKey)),
           matching: find.text(teacher)),
       findsOneWidget);
-      */
   expect(true, true);
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 ### Fixed
+- Fix inconsistency in lecture display
 
 ## [1.1.0] - 2021-04-18
 


### PR DESCRIPTION
Closes #354 and eventually #355 .

There are two different constructors for lectures and they were inconsistent on how they handled schedules.

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
