### PR TITLE
Small Release/Docs Fixes

### DIFF
--- a/app_feup/README.md
+++ b/app_feup/README.md
@@ -38,7 +38,7 @@ To release the app, a few steps are required:
 - Make sure you have completed the **Requirements** section of this README
 - Increase the version in pubspec.yaml
 - Fill the fields in android/key.properties. [This might require creation of a store](https://flutter.dev/docs/deployment/android)
-- Run `flutter build appbundle lib/Main.dart` to generate the bundle ready for upload
+- Run `flutter build appbundle lib/main.dart` to generate the bundle ready for upload
 - Make sure the Play Store's Content Rating is accurate before rolling out the app
 
 [Here's the full guide to releasing a flutter application](https://flutter.dev/docs/deployment/android)

--- a/app_feup/android/app/build.gradle
+++ b/app_feup/android/app/build.gradle
@@ -32,7 +32,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         applicationId "pt.up.fe.ni.uni"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.0+2
+version: 1.1.1+20
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #359 
Fixes semantic versioning sets target android SDK to 29, fixes `main.dart` file path in `README.md`

# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [ ] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [ ] Clean, well structured code
