### PR TITLE
Fix flutter cache manager exporting File API

### DIFF
--- a/app_feup/lib/controller/local_storage/image_offline_storage.dart
+++ b/app_feup/lib/controller/local_storage/image_offline_storage.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:image/image.dart';
 import 'package:connectivity/connectivity.dart';
 
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' show DefaultCacheManager;
 import 'package:path_provider/path_provider.dart';
 
 Future<String> get _localPath async {

--- a/app_feup/lib/controller/logout.dart
+++ b/app_feup/lib/controller/logout.dart
@@ -5,7 +5,7 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' show DefaultCacheManager;
 import 'package:uni/controller/local_storage/app_bus_stop_database.dart';
 import 'package:uni/controller/local_storage/app_courses_database.dart';
 import 'package:uni/controller/local_storage/app_exams_database.dart';

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.1+20
+version: 1.1.1+21
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
`flutter_cache_manager` is now exposing the `File` API from the [file package](https://github.com/google/file.dart), which enters in direct conflict with `dart:io`'s `File`'s API. This PR fixes that error by only exposing the cache manager from `flutter_cache_manager`. 
More information on it can be found here: https://github.com/Baseflow/flutter_cache_manager/issues/320

This PR will fix the issues in #346 
# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [ ] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [ ] Clean, well structured code
