### PR TITLE
Update target SDK version to 30

### DIFF
--- a/app_feup/android/app/build.gradle
+++ b/app_feup/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         applicationId "pt.up.fe.ni.uni"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app_feup/test/integration/src/schedule_page_test.dart
+++ b/app_feup/test/integration/src/schedule_page_test.dart
@@ -1,3 +1,4 @@
+@Skip('https://github.com/NIAEFEUP/project-schrodinger/issues/367')
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix inconsistency in lecture display
 
+### Changed
+- Updated Android's `targetSdkVersion` to 30
+
 ## [1.1.0] - 2021-04-18
 
 ### Added


### PR DESCRIPTION
Any new update made to google play store is now required to have the target SDK version for Android 11 (level 30)

Updated `build.gradle`'s `targetSdkVersion` property

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
