### PR TITLE
Remove duplicated exams from parser

### DIFF
--- a/app_feup/lib/controller/parsers/parser_exams.dart
+++ b/app_feup/lib/controller/parsers/parser_exams.dart
@@ -13,10 +13,10 @@ class ParserExams {
     return '?';
   }
 
-  Future<List<Exam>> parseExams(http.Response response) async {
+  Future<Set<Exam>> parseExams(http.Response response) async {
     final document = parse(response.body);
 
-    final List<Exam> examsList = [];
+    final Set<Exam> examsList = Set();
     final List<String> dates = [];
     final List<String> examTypes = [];
     final List<String> weekDays = [];

--- a/app_feup/lib/model/entities/exam.dart
+++ b/app_feup/lib/model/entities/exam.dart
@@ -1,4 +1,5 @@
 import 'package:logger/logger.dart';
+import 'package:collection/collection.dart';
 
 var months = {
   'Janeiro': '01',
@@ -102,6 +103,33 @@ class Exam {
   String toString() {
     return '''$subject - $year - $month - $day -  $begin-$end - $examType - $rooms - $weekDay''';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Exam &&
+          runtimeType == other.runtimeType &&
+          subject == other.subject &&
+          begin == other.begin &&
+          end == other.end &&
+          ListEquality().equals(rooms, other.rooms) &&
+          day == other.day &&
+          examType == other.examType &&
+          weekDay == other.weekDay &&
+          month == other.month &&
+          year == other.year;
+
+  @override
+  int get hashCode =>
+      subject.hashCode ^
+      begin.hashCode ^
+      end.hashCode ^
+      ListEquality().hash(rooms) ^
+      day.hashCode ^
+      examType.hashCode ^
+      weekDay.hashCode ^
+      month.hashCode ^
+      year.hashCode;
 
   static Map<String, String> getExamTypes() {
     return _types;

--- a/app_feup/lib/redux/action_creators.dart
+++ b/app_feup/lib/redux/action_creators.dart
@@ -190,20 +190,20 @@ ThunkAction<AppState> updateStateBasedOnLocalRefreshTimes() {
 
 Future<List<Exam>> extractExams(
     Store<AppState> store, ParserExams parserExams) async {
-  List<Exam> courseExams = [];
+  Set<Exam> courseExams = Set();
   for (Course course in store.state.content['profile'].courses) {
-    final List<Exam> currentCourseExams = await parserExams.parseExams(
+    final Set<Exam> currentCourseExams = await parserExams.parseExams(
         await NetworkRouter.getWithCookies(
             NetworkRouter.getBaseUrlFromSession(
                     store.state.content['session']) +
                 'exa_geral.mapa_de_exames?p_curso_id=${course.id}',
             {},
             store.state.content['session']));
-    courseExams = List.from(courseExams)..addAll(currentCourseExams);
+    courseExams = Set.from(courseExams)..addAll(currentCourseExams);
   }
 
   final List<CourseUnit> userUcs = store.state.content['currUcs'];
-  final List<Exam> exams = <Exam>[];
+  final Set<Exam> exams = Set();
   for (Exam courseExam in courseExams) {
     for (CourseUnit uc in userUcs) {
       if (!courseExam.examType.contains(
@@ -215,7 +215,8 @@ Future<List<Exam>> extractExams(
       }
     }
   }
-  return exams;
+
+  return exams.toList();
 }
 
 ThunkAction<AppState> getUserExams(Completer<Null> action,

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.1+21
+version: 1.1.1+22
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/app_feup/test/unit/redux/exam_action_creators_test.dart
+++ b/app_feup/test/unit/redux/exam_action_creators_test.dart
@@ -45,7 +45,8 @@ void main() {
       final Completer<Null> completer = Completer();
       final actionCreator =
           getUserExams(completer, parserMock, userPersistentInfo);
-      when(parserMock.parseExams(any)).thenAnswer((_) async => [sopeExam]);
+      when(parserMock.parseExams(any))
+          .thenAnswer((_) async => [sopeExam].toSet());
 
       actionCreator(mockStore);
       await completer.future;
@@ -61,7 +62,7 @@ void main() {
       final actionCreator =
           getUserExams(completer, parserMock, userPersistentInfo);
       when(parserMock.parseExams(any))
-          .thenAnswer((_) async => [sopeExam, sdisExam]);
+          .thenAnswer((_) async => [sopeExam, sdisExam].toSet());
 
       actionCreator(mockStore);
       await completer.future;
@@ -85,7 +86,7 @@ void main() {
       final actionCreator =
           getUserExams(completer, parserMock, userPersistentInfo);
       when(parserMock.parseExams(any))
-          .thenAnswer((_) async => [sopeExam, sdisExam, specialExam]);
+          .thenAnswer((_) async => [sopeExam, sdisExam, specialExam].toSet());
 
       actionCreator(mockStore);
       await completer.future;
@@ -127,7 +128,8 @@ void main() {
       final Completer<Null> completer = Completer();
       final actionCreator =
           getUserExams(completer, parserMock, userPersistentInfo);
-      when(parserMock.parseExams(any)).thenAnswer((_) async => [todayExam]);
+      when(parserMock.parseExams(any))
+          .thenAnswer((_) async => [todayExam].toSet());
 
       actionCreator(mockStore);
       await completer.future;
@@ -154,7 +156,8 @@ void main() {
       final Completer<Null> completer = Completer();
       final actionCreator =
           getUserExams(completer, parserMock, userPersistentInfo);
-      when(parserMock.parseExams(any)).thenAnswer((_) async => [todayExam]);
+      when(parserMock.parseExams(any))
+          .thenAnswer((_) async => [todayExam].toSet());
 
       actionCreator(mockStore);
       await completer.future;
@@ -181,7 +184,8 @@ void main() {
       final Completer<Null> completer = Completer();
       final actionCreator =
           getUserExams(completer, parserMock, userPersistentInfo);
-      when(parserMock.parseExams(any)).thenAnswer((_) async => [todayExam]);
+      when(parserMock.parseExams(any))
+          .thenAnswer((_) async => [todayExam].toSet());
 
       actionCreator(mockStore);
       await completer.future;

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix inconsistency in lecture display
+- Fix possible duplicated exams during parsing
 
 ### Changed
 - Updated Android's `targetSdkVersion` to 30


### PR DESCRIPTION

Closes #371 
Avoids any duplicated exams due parsing errors.

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
