### PR TITLE
Fix new header for github issues

### DIFF
--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -186,7 +186,7 @@ class BugReportFormState extends State<BugReportForm> {
         ? 'Unidentified bug'
         : bugDescriptions[_selectedBug].item2;
     final Map data = {
-      'headline6': titleController.text,
+      'title': titleController.text,
       'body': descriptionController.text,
       'labels': [_issueLabel, bugLabel]
     };

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix inconsistency in lecture display
 - Fix possible duplicated exams during parsing
+- Fix Github issues header changes
 
 ### Changed
 - Updated Android's `targetSdkVersion` to 30


### PR DESCRIPTION
Headers in order to post issue in github have changed, this PR fixes that.

# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [ ] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [ ] Clean, well structured code
