### PR TITLE
Fix tests for the different schedule fetchers

### DIFF
--- a/app_feup/lib/model/entities/lecture.dart
+++ b/app_feup/lib/model/entities/lecture.dart
@@ -62,7 +62,7 @@ class Lecture {
       String classNumber) {
     final startTimeHours = (startTimeSeconds ~/ 3600);
     final startTimeMinutes = ((startTimeSeconds % 3600) ~/ 60);
-    final endTimeSeconds = 60 * 30 * blocks;
+    final endTimeSeconds = 60 * 30 * blocks + startTimeSeconds;
     final endTimeHours = (endTimeSeconds ~/ 3600);
     final endTimeMinutes = ((endTimeSeconds % 3600) ~/ 60);
     final lecture = Lecture(

--- a/app_feup/lib/view/Pages/schedule_page_view.dart
+++ b/app_feup/lib/view/Pages/schedule_page_view.dart
@@ -108,6 +108,7 @@ class SchedulePageView extends StatelessWidget {
       contentChecker: aggLectures[day].isNotEmpty,
       onNullContent:
           Center(child: Text('Não possui aulas à ' + daysOfTheWeek[day] + '.')),
+      index: day,
     );
   }
 }

--- a/app_feup/lib/view/Widgets/request_dependent_widget_builder.dart
+++ b/app_feup/lib/view/Widgets/request_dependent_widget_builder.dart
@@ -13,6 +13,7 @@ class RequestDependentWidgetBuilder extends StatelessWidget {
     @required this.content,
     @required this.contentChecker,
     @required this.onNullContent,
+    this.index
   }) : super(key: key);
 
   final BuildContext context;
@@ -21,6 +22,7 @@ class RequestDependentWidgetBuilder extends StatelessWidget {
   final content;
   final bool contentChecker;
   final Widget onNullContent;
+  final int index;
   static final AppLastUserInfoUpdateDatabase lastUpdateDatabase =
       AppLastUserInfoUpdateDatabase();
 

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.1+23
+version: 1.1.1+24
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/app_feup/test/integration/resources/schedule_example.json
+++ b/app_feup/test/integration/resources/schedule_example.json
@@ -1,0 +1,274 @@
+{
+  "blocos": [
+    {
+      "semana_ini": "2021-10-17",
+      "semana_fim": "2021-10-23",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-10-24",
+      "semana_fim": "2021-10-30",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-10-31",
+      "semana_fim": "2021-11-06",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-11-07",
+      "semana_fim": "2021-11-13",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-11-14",
+      "semana_fim": "2021-11-20",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-11-21",
+      "semana_fim": "2021-11-27",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-11-28",
+      "semana_fim": "2021-12-04",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-12-05",
+      "semana_fim": "2021-12-11",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2021-12-12",
+      "semana_fim": "2021-12-18",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    },
+    {
+      "semana_ini": "2022-01-02",
+      "semana_fim": "2022-01-22",
+      "bloco_codigo": null,
+      "c_turma_id": null,
+      "turmas_bloco": "",
+      "turma_real": "",
+      "periodo": ""
+    }
+  ],
+  "horario": [
+    {
+      "dia": 2,
+      "hora_inicio": 39600,
+      "ucurr_sigla": "ASSO",
+      "ocorrencia_id": 484406,
+      "tipo": "TP",
+      "aula_id": 5877394,
+      "aula_duracao": 2,
+      "sala_sigla": "EaD",
+      "salas": [
+        {
+          "espaco_id": 73218,
+          "espaco_nome": "B323"
+        }
+      ],
+      "doc_sigla": "DRP",
+      "docentes": [
+        {
+          "doc_codigo": "211847",
+          "doc_nome": "Jaime Enrique Villate Matiz"
+        }
+      ],
+      "turma_sigla": "2LEIC12",
+      "turmas": [
+        {
+          "turma_id": 211027,
+          "turma_sigla": "2LEIC12"
+        }
+      ],
+      "periodo": 2
+    },
+    {
+      "dia": 5,
+      "hora_inicio": 50400,
+      "ucurr_sigla": "IOPE",
+      "ocorrencia_id": 484406,
+      "tipo": "TE",
+      "aula_id": 5877072,
+      "aula_duracao": 2,
+      "sala_sigla": "EaD",
+      "salas": [],
+      "doc_sigla": "MTD",
+      "docentes": [
+        {
+          "doc_codigo": "470161",
+          "doc_nome": "Mercedes Esteves Filho"
+        }
+      ],
+      "turma_sigla": "COMP_1635",
+      "turmas": [
+        {
+          "turma_id": 211028,
+          "turma_sigla": "2LEIC13"
+        },
+        {
+          "turma_id": 211029,
+          "turma_sigla": "2LEIC14"
+        },
+        {
+          "turma_id": 211025,
+          "turma_sigla": "2LEIC10"
+        },
+        {
+          "turma_id": 211027,
+          "turma_sigla": "2LEIC12"
+        },
+        {
+          "turma_id": 211030,
+          "turma_sigla": "2LEIC15"
+        },
+        {
+          "turma_id": 211031,
+          "turma_sigla": "2LEIC16"
+        },
+        {
+          "turma_id": 211026,
+          "turma_sigla": "2LEIC11"
+        },
+        {
+          "turma_id": 211024,
+          "turma_sigla": "2LEIC09"
+        }
+      ],
+      "periodo": 2
+    },
+    {
+      "dia": 3,
+      "hora_inicio": 50400,
+      "ucurr_sigla": "AED",
+      "ocorrencia_id": 484404,
+      "tipo": "TP",
+      "aula_id": 5877541,
+      "aula_duracao": 2,
+      "sala_sigla": "B101",
+      "salas": [
+        {
+          "espaco_id": 73388,
+          "espaco_nome": "B101"
+        }
+      ],
+      "doc_sigla": "RR",
+      "docentes": [
+        {
+          "doc_codigo": "419241",
+          "doc_nome": "Rosaldo Jos\u00E9 Fernandes Rossetti"
+        }
+      ],
+      "turma_sigla": "2LEIC10",
+      "turmas": [
+        {
+          "turma_id": 211025,
+          "turma_sigla": "2LEIC10"
+        }
+      ],
+      "periodo": 2
+    },
+    {
+      "dia": 6,
+      "hora_inicio": 50400,
+      "ucurr_sigla": "LDTS",
+      "ocorrencia_id": 484407,
+      "tipo": "PL",
+      "aula_id": 5877553,
+      "aula_duracao": 2,
+      "sala_sigla": "B101",
+      "salas": [
+        {
+          "espaco_id": 73388,
+          "espaco_nome": "B101"
+        }
+      ],
+      "doc_sigla": "BMCL",
+      "docentes": [
+        {
+          "doc_codigo": "547486",
+          "doc_nome": "Bruno Miguel Carvalhido Lima"
+        }
+      ],
+      "turma_sigla": "2LEIC10",
+      "turmas": [
+        {
+          "turma_id": 211025,
+          "turma_sigla": "2LEIC10"
+        }
+      ],
+      "periodo": 2
+    },
+    {
+      "dia": 6,
+      "hora_inicio": 57600,
+      "ucurr_sigla": "BD",
+      "ocorrencia_id": 484405,
+      "tipo": "TP",
+      "aula_id": 5877550,
+      "aula_duracao": 2,
+      "sala_sigla": "B101",
+      "salas": [
+        {
+          "espaco_id": 73388,
+          "espaco_nome": "B101"
+        }
+      ],
+      "doc_sigla": "PES",
+      "docentes": [
+        {
+          "doc_codigo": "665577",
+          "doc_nome": "Pedro Emanuel Cardoso de Sousa"
+        }
+      ],
+      "turma_sigla": "2LEIC10",
+      "turmas": [
+        {
+          "turma_id": 211025,
+          "turma_sigla": "2LEIC10"
+        }
+      ],
+      "periodo": 2
+    }
+  ]
+}

--- a/app_feup/test/integration/src/schedule_page_test.dart
+++ b/app_feup/test/integration/src/schedule_page_test.dart
@@ -1,4 +1,3 @@
-@Skip('https://github.com/NIAEFEUP/project-schrodinger/issues/367')
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
@@ -27,10 +26,18 @@ class MockClient extends Mock implements http.Client {}
 
 class MockResponse extends Mock implements http.Response {}
 
+class UriMatcher extends CustomMatcher {
+  UriMatcher(matcher) : super('Uri that has', 'string', matcher);
+
+  @override
+  Object featureValueOf(actual) => (actual as Uri).toString();
+}
+
 void main() {
   group('SchedulePage Integration Tests', () {
     final mockClient = MockClient();
     final mockResponse = MockResponse();
+    final badMockResponse = MockResponse();
     final subject1 = 'ASSO';
     final startTime1 = '11h00';
     final endTime1 = '13h00';
@@ -45,25 +52,22 @@ void main() {
     final typeClass2 = 'TE';
     final teacher2 = 'MTD';
 
-    final profile = Profile();
-    profile.courses = [Course(id: 7474)];
-    final store = Store<AppState>(appReducers,
-        initialState: AppState({
-          'session': Session(authenticated: true),
-          'scheduleStatus': RequestStatus.none,
-          'schedule': <Lecture>[],
-          'profile': profile
-        }),
-        middleware: [generalMiddleware]);
-    NetworkRouter.httpClient = mockClient;
-    testWidgets('Schedule', (WidgetTester tester) async {
-      final mockHtml = File('test/integration/resources/schedule_example.html')
-          .readAsStringSync(encoding: Latin1Codec());
-      when(mockResponse.body).thenReturn(mockHtml);
-      when(mockResponse.statusCode).thenReturn(200);
-      when(mockClient.get(any, headers: anyNamed('headers')))
-          .thenAnswer((_) async => mockResponse);
+    final htmlFetcherIdentifier = 'hor_geral.estudantes_view';
+    final jsonFetcherIdentifier = 'mob_hor_geral.estudante?pv_codigo';
 
+    Future testSchedule(WidgetTester tester) async {
+      final profile = Profile();
+      profile.courses = [Course(id: 7474)];
+      final store = Store<AppState>(appReducers,
+          initialState: AppState({
+            'session': Session(authenticated: true),
+            'scheduleStatus': RequestStatus.none,
+            'schedule': <Lecture>[],
+            'profile': profile
+          }),
+          middleware: [generalMiddleware]);
+      NetworkRouter.httpClient = mockClient;
+      when(badMockResponse.statusCode).thenReturn(500);
       final Completer<Null> completer = Completer();
       final actionCreator = getUserSchedule(completer, Tuple2('', ''));
 
@@ -81,6 +85,11 @@ void main() {
 
       await completer.future;
 
+      await tester.tap(find.byKey(Key('schedule-page-tab-2')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(Key('schedule-page-tab-1')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.byKey(Key('schedule-page-tab-0')));
       await tester.pumpAndSettle();
 
       testScheduleSlot(
@@ -93,6 +102,40 @@ void main() {
 
       testScheduleSlot(
           subject2, startTime2, endTime2, room2, typeClass2, teacher2);
+    }
+
+    testWidgets('Schedule with JSON Fetcher', (WidgetTester tester) async {
+      NetworkRouter.httpClient = mockClient;
+      when(badMockResponse.statusCode).thenReturn(500);
+      final mockHtml = File('test/integration/resources/schedule_example.json')
+          .readAsStringSync(encoding: Latin1Codec());
+      when(mockResponse.body).thenReturn(mockHtml);
+      when(mockResponse.statusCode).thenReturn(200);
+      when(mockClient.get(argThat(UriMatcher(contains(htmlFetcherIdentifier))),
+              headers: anyNamed('headers')))
+          .thenAnswer((_) async => badMockResponse);
+
+      when(mockClient.get(argThat(UriMatcher(contains(jsonFetcherIdentifier))),
+              headers: anyNamed('headers')))
+          .thenAnswer((_) async => mockResponse);
+
+      await testSchedule(tester);
+    });
+
+    testWidgets('Schedule with HTML Fetcher', (WidgetTester tester) async {
+      final mockHtml = File('test/integration/resources/schedule_example.html')
+          .readAsStringSync(encoding: Latin1Codec());
+      when(mockResponse.body).thenReturn(mockHtml);
+      when(mockResponse.statusCode).thenReturn(200);
+      when(mockClient.get(argThat(UriMatcher(contains(htmlFetcherIdentifier))),
+              headers: anyNamed('headers')))
+          .thenAnswer((_) async => mockResponse);
+
+      when(mockClient.get(argThat(UriMatcher(contains(jsonFetcherIdentifier))),
+              headers: anyNamed('headers')))
+          .thenAnswer((_) async => badMockResponse);
+
+      await testSchedule(tester);
     });
   });
 }

--- a/app_feup/test/unit/view/Widgets/schedule_slot_test.dart
+++ b/app_feup/test/unit/view/Widgets/schedule_slot_test.dart
@@ -5,8 +5,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:uni/view/Widgets/schedule_slot.dart';
 import '../../../testable_widget.dart';
 
-// TO DO: Fix this test
-// https://github.com/NIAEFEUP/project-schrodinger/issues/354
 void testScheduleSlot(String subject, String begin, String end, String rooms,
     String typeClass, String teacher) {
   final scheduleSlotTimeKey = 'schedule-slot-time-$begin-$end';

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix inconsistency in lecture display
 - Fix possible duplicated exams during parsing
 - Fix Github issues header changes
+- Fix Lecture data coming from Sigarra's API
 
 ### Changed
 - Updated Android's `targetSdkVersion` to 30


### PR DESCRIPTION
Closes #367 
Tests were not adapted to the fact that we had the means to retrieve the data from two different fetchers and needed to be adapted.

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
