### PR TITLE
fix: show lecture end time instead of duration

### DIFF
--- a/app_feup/lib/model/entities/lecture.dart
+++ b/app_feup/lib/model/entities/lecture.dart
@@ -62,7 +62,7 @@ class Lecture {
       String classNumber) {
     final startTimeHours = (startTimeSeconds ~/ 3600);
     final startTimeMinutes = ((startTimeSeconds % 3600) ~/ 60);
-    final endTimeSeconds = 60 * 30 * blocks;
+    final endTimeSeconds = 60 * 30 * blocks + startTimeSeconds;
     final endTimeHours = (endTimeSeconds ~/ 3600);
     final endTimeMinutes = ((endTimeSeconds % 3600) ~/ 60);
     final lecture = Lecture(

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.1+23
+version: 1.1.1+24
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #406.

This pull request fix a bug where the lecture duration was shown instead of the lecture's end time. This was caused by the start time (in seconds) not being added to the duration (also in seconds) in the Lecture.fromApi factory.

Steps to reproduce are:
  - Go to uni
  - Wait until the app fetches your lectures from the API
  - The duration should appear instead of the lecture's end time

I still haven't tested these changed and will update the review checklist as soon as I do.

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [x] Clean, well structured code
