### PR TITLE
Get CSRF token for bus stops departures

### DIFF
--- a/app_feup/lib/controller/bus_stops/departures_fetcher.dart
+++ b/app_feup/lib/controller/bus_stops/departures_fetcher.dart
@@ -1,0 +1,96 @@
+import 'package:uni/model/entities/bus_stop.dart';
+import 'package:http/http.dart' as http;
+import 'package:html/parser.dart';
+import 'package:uni/model/entities/trip.dart';
+import 'package:uni/controller/networking/network_router.dart';
+
+class DeparturesFetcher {
+  final String _stopCode;
+  final BusStopData _stopData;
+
+  DeparturesFetcher(this._stopCode, this._stopData);
+
+  Future<String> _getCSRFToken() async {
+    final url =
+        'https://www.stcp.pt/en/travel/timetables/?paragem=$_stopCode&t=smsbus';
+
+    final http.Response response = await http.get(url.toUri());
+    final htmlResponse = parse(response.body);
+
+    final scriptText = htmlResponse
+        .querySelectorAll('script')
+        .where((element) => element.text.contains(_stopCode))
+        .map((e) => e.text)
+        .first;
+
+    final callParam = scriptText
+        .substring(scriptText.indexOf('('))
+        .split(',')
+        .firstWhere((element) => element.contains(')'));
+
+    final csrfToken = callParam.substring(
+        callParam.indexOf('\'') + 1, callParam.lastIndexOf('\''));
+
+    return csrfToken;
+  }
+
+  void throwCSRFTokenError() {
+    throw Exception('No CSRF token found!');
+  }
+
+  Future<List<Trip>> getDepartures() async {
+    final csrfToken = await _getCSRFToken();
+
+    final url =
+        'https://www.stcp.pt/pt/itinerarium/soapclient.php?codigo=$_stopCode&hash123=$csrfToken';
+
+    final http.Response response = await http.get(url.toUri());
+    final htmlResponse = parse(response.body);
+
+    final tableEntries =
+        htmlResponse.querySelectorAll('#smsBusResults > tbody > tr.even');
+
+    final configuredBuses = _stopData.configuredBuses;
+
+    final tripList = <Trip>[];
+
+    for (var entry in tableEntries) {
+      final rawBusInformation = entry.querySelectorAll('td');
+
+      final busLine = rawBusInformation[0].querySelector('ul > li').text.trim();
+
+      if (!configuredBuses.contains(busLine)) {
+        continue;
+      }
+
+      final busDestination = rawBusInformation[0]
+          .text
+          .replaceAll('\n', '')
+          .replaceAll('\t', '')
+          .replaceAll(' ', '')
+          .replaceAll('-', '')
+          .substring(busLine.length + 1);
+
+      final busTimeRemaining = getBusTimeRemaining(rawBusInformation);
+
+      final Trip newTrip = Trip(
+          line: busLine,
+          destination: busDestination,
+          timeRemaining: busTimeRemaining);
+
+      tripList.add(newTrip);
+    }
+    return tripList;
+  }
+
+  /// Extracts the time remaining for a bus to reach a stop.
+  static int getBusTimeRemaining(rawBusInformation) {
+    if (rawBusInformation[1].text.trim() == 'a passar') {
+      return 0;
+    } else {
+      final regex = RegExp(r'([0-9]+)');
+
+      return int.parse(regex.stringMatch(rawBusInformation[2].text).toString());
+    }
+  }
+}

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -7,7 +7,7 @@ description: A FEUP no teu bolso
 # Both the version and the builder number may be overridden in flutter
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
-version: 1.1.1+24
+version: 1.1.1+25
 
 environment:
   sdk: ">=2.7.0 <3.0.0"

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix possible duplicated exams during parsing
 - Fix Github issues header changes
 - Fix Lecture data coming from Sigarra's API
+- Fix Bus Stops departures, to obtain new CSRF for the API
 
 ### Changed
 - Updated Android's `targetSdkVersion` to 30


### PR DESCRIPTION
Closes #382 

The API now requires a CSRF token that we are able to obtain from the website itself. Introduced that in order to fix the bus stops

# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [x] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [x] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
