### PR TITLE
Feature/refactor theme properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,11 @@
 .pub/
 build/
 *.bin
-
 app_feup/pubspec.lock
+
+# IDE files
 .DS_Store
 .atom/
 .vscode/
-.packages
+.idea/
+.gradle/

--- a/app_feup/android/key.properties
+++ b/app_feup/android/key.properties
@@ -1,4 +1,4 @@
-storePassword=keystore_password_here
-keyPassword=keystore_password_here
-keyAlias=key
-storeFile=keystore_path_here
+storePassword=q72Yqcug3x3JXqpn
+keyPassword=q72Yqcug3x3JXqpn
+keyAlias=upload
+storeFile=/home/bdmendes/Documents/NI/uni-secret/newnewkey/upload-keystore.jks

--- a/app_feup/lib/controller/local_storage/app_shared_preferences.dart
+++ b/app_feup/lib/controller/local_storage/app_shared_preferences.dart
@@ -77,13 +77,6 @@ class AppSharedPreferences {
     return prefs.setInt(themeMode, thmMode.index);
   }
 
-  /// Switch to next available theme mode.
-  static Future<bool> setNextThemeMode() async {
-    final prefs = await SharedPreferences.getInstance();
-    final themeIndex = (await getThemeMode()).index;
-    return prefs.setInt(themeMode, (themeIndex + 1) % 3);
-  }
-
   /// Deletes the user's student number and password.
   static Future removePersistentUserInfo() async {
     final prefs = await SharedPreferences.getInstance();

--- a/app_feup/lib/controller/local_storage/app_shared_preferences.dart
+++ b/app_feup/lib/controller/local_storage/app_shared_preferences.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:encrypt/encrypt.dart' as encrypt;
-import 'package:encrypt/encrypt.dart';
 import 'package:flutter/material.dart';
 import 'package:logger/logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -78,7 +77,14 @@ class AppSharedPreferences {
     return prefs.setInt(themeMode, thmMode.index);
   }
 
-  /// Deletes the user's student number and passoword.
+  /// Switch to next available theme mode.
+  static Future<bool> setNextThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final themeIndex = (await getThemeMode()).index;
+    return prefs.setInt(themeMode, (themeIndex + 1) % 3);
+  }
+
+  /// Deletes the user's student number and password.
   static Future removePersistentUserInfo() async {
     final prefs = await SharedPreferences.getInstance();
     prefs.remove(userNumber);
@@ -146,7 +152,7 @@ class AppSharedPreferences {
     prefs.setStringList(filteredExamsTypes, newTypes);
   }
 
-  // Returns the user's exam filter settings.
+  /// Returns the user's exam filter settings.
   static Future<Map<String, bool>> getFilteredExams() async {
     final prefs = await SharedPreferences.getInstance();
     final List<String> storedFilteredExamTypes =

--- a/app_feup/lib/main.dart
+++ b/app_feup/lib/main.dart
@@ -24,7 +24,6 @@ import 'package:uni/view/Widgets/page_transition.dart';
 import 'package:uni/view/navigation_service.dart';
 import 'package:uni/view/theme.dart';
 import 'package:uni/view/theme_notifier.dart';
-
 import 'controller/on_start_up.dart';
 import 'model/schedule_page_model.dart';
 

--- a/app_feup/lib/model/entities/exam.dart
+++ b/app_feup/lib/model/entities/exam.dart
@@ -2,18 +2,18 @@ import 'package:logger/logger.dart';
 import 'package:collection/collection.dart';
 
 var months = {
-  'Janeiro': '01',
-  'Fevereiro': '02',
-  'Março': '03',
-  'Abril': '04',
-  'Maio': '05',
-  'Junho': '06',
-  'Julho': '07',
-  'Agosto': '08',
-  'Setembro': '09',
-  'Outubro': '10',
-  'Novembro': '11',
-  'Dezembro': '12'
+  'janeiro': '01',
+  'fevereiro': '02',
+  'março': '03',
+  'abril': '04',
+  'maio': '05',
+  'junho': '06',
+  'julho': '07',
+  'agosto': '08',
+  'setembro': '09',
+  'outubro': '10',
+  'novembro': '11',
+  'dezembro': '12'
 };
 
 var _types = {

--- a/app_feup/lib/utils/constants.dart
+++ b/app_feup/lib/utils/constants.dart
@@ -2,7 +2,7 @@ library Constants;
 
 const navPersonalArea = 'Área Pessoal';
 const navSchedule = 'Horário';
-const navExams = 'Mapa de Exames';
+const navExams = 'Exames';
 const navStops = 'Autocarros';
 const navAbout = 'Sobre';
 const navBugReport = 'Bugs e Sugestões';

--- a/app_feup/lib/view/Pages/about_page_view.dart
+++ b/app_feup/lib/view/Pages/about_page_view.dart
@@ -18,7 +18,7 @@ class AboutPageViewState extends GeneralPageViewState {
         Container(
             child: SvgPicture.asset(
           'assets/images/ni_logo.svg',
-          // color: Theme.of(context).accentColor,
+          color: Theme.of(context).primaryColor,
           width: queryData.size.height / 7,
           height: queryData.size.height / 7,
         )),

--- a/app_feup/lib/view/Pages/about_page_view.dart
+++ b/app_feup/lib/view/Pages/about_page_view.dart
@@ -18,7 +18,7 @@ class AboutPageViewState extends GeneralPageViewState {
         Container(
             child: SvgPicture.asset(
           'assets/images/ni_logo.svg',
-          color: Theme.of(context).accentColor,
+          // color: Theme.of(context).accentColor,
           width: queryData.size.height / 7,
           height: queryData.size.height / 7,
         )),

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -103,7 +103,7 @@ class _NextArrivalsState extends State<NextArrivals>
       result.addAll(this.getContent(context));
     } else {
       result.add(Container(
-          child: Text('Não se encontram configuradas paragens',
+          child: Text('Não existe nenhuma paragem configurada',
               style: Theme.of(context).textTheme.headline6)));
     }
 

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -136,10 +136,12 @@ class _NextArrivalsState extends State<NextArrivals>
     result.addAll(this.getHeader(context));
     result.add(Container(
         padding: EdgeInsets.only(bottom: 12.0),
-        child: Text('Não foi possível obter informação',
-            maxLines: 2,
-            overflow: TextOverflow.fade,
-            style: Theme.of(context).textTheme.bodyText1)));
+        child: Text(
+          'Não foi possível obter informação',
+          maxLines: 2,
+          overflow: TextOverflow.fade,
+          /* style: Theme.of(context).textTheme.bodyText1 */
+        )));
 
     return result;
   }
@@ -158,7 +160,7 @@ class _NextArrivalsState extends State<NextArrivals>
               ),
               IconButton(
                   icon: Icon(Icons.edit),
-                  color: Theme.of(context).accentColor,
+                  // color: Theme.of(context).accentColor,
                   onPressed: () => Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -136,12 +136,10 @@ class _NextArrivalsState extends State<NextArrivals>
     result.addAll(this.getHeader(context));
     result.add(Container(
         padding: EdgeInsets.only(bottom: 12.0),
-        child: Text(
-          'Não foi possível obter informação',
-          maxLines: 2,
-          overflow: TextOverflow.fade,
-          /* style: Theme.of(context).textTheme.bodyText1 */
-        )));
+        child: Text('Não foi possível obter informação',
+            maxLines: 2,
+            overflow: TextOverflow.fade,
+            style: Theme.of(context).textTheme.subtitle1)));
 
     return result;
   }

--- a/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
+++ b/app_feup/lib/view/Pages/bus_stop_next_arrivals_page.dart
@@ -103,8 +103,8 @@ class _NextArrivalsState extends State<NextArrivals>
       result.addAll(this.getContent(context));
     } else {
       result.add(Container(
-          child: Text('Não se encontram configurados autocarros',
-              style: Theme.of(context).textTheme.headline4)));
+          child: Text('Não se encontram configuradas paragens',
+              style: Theme.of(context).textTheme.headline6)));
     }
 
     return result;
@@ -160,7 +160,6 @@ class _NextArrivalsState extends State<NextArrivals>
               ),
               IconButton(
                   icon: Icon(Icons.edit),
-                  // color: Theme.of(context).accentColor,
                   onPressed: () => Navigator.push(
                       context,
                       MaterialPageRoute(

--- a/app_feup/lib/view/Pages/exams_page_view.dart
+++ b/app_feup/lib/view/Pages/exams_page_view.dart
@@ -123,9 +123,9 @@ class ExamsList extends StatelessWidget {
         key: Key(keyValue),
         margin: EdgeInsets.fromLTRB(12, 4, 12, 0),
         child: RowContainer(
-            color: isHighlighted(exam)
+/*             color: isHighlighted(exam)
                 ? Theme.of(context).hintColor
-                : Theme.of(context).backgroundColor,
+                : Theme.of(context).backgroundColor, */
             child: ScheduleRow(
                 subject: exam.subject,
                 rooms: exam.rooms,

--- a/app_feup/lib/view/Pages/exams_page_view.dart
+++ b/app_feup/lib/view/Pages/exams_page_view.dart
@@ -123,9 +123,9 @@ class ExamsList extends StatelessWidget {
         key: Key(keyValue),
         margin: EdgeInsets.fromLTRB(12, 4, 12, 0),
         child: RowContainer(
-/*             color: isHighlighted(exam)
+            color: isHighlighted(exam)
                 ? Theme.of(context).hintColor
-                : Theme.of(context).backgroundColor, */
+                : Theme.of(context).scaffoldBackgroundColor,
             child: ScheduleRow(
                 subject: exam.subject,
                 rooms: exam.rooms,

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -11,7 +11,7 @@ import 'package:uni/model/profile_page_model.dart';
 import 'package:uni/view/Widgets/navigation_drawer.dart';
 import 'package:uni/utils/constants.dart' as Constants;
 
-/// Manages the  section inside the user's personal area.
+/// Manages the section inside the user's personal area.
 abstract class GeneralPageViewState extends State<StatefulWidget> {
   final double borderMargin = 18.0;
   static FileImage decorageImage;
@@ -57,7 +57,6 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
           key: GlobalKey<RefreshIndicatorState>(),
           child: child,
           onRefresh: refresh,
-          /* color: Theme.of(context).accentColor */
         );
       },
     );
@@ -82,14 +81,14 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
       bottom: PreferredSize(
         preferredSize: Size.zero,
         child: Container(
+          color: Theme.of(context).dividerColor,
           margin: EdgeInsets.only(left: borderMargin, right: borderMargin),
-          // color: Theme.of(context).dividerColor,
           height: 1.5,
         ),
       ),
       elevation: 0,
-      // iconTheme: IconThemeData(color: Theme.of(context).accentColor),
-      // backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      iconTheme: IconThemeData(color: Theme.of(context).primaryColor),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       titleSpacing: 0.0,
       title: ButtonTheme(
           minWidth: 0,

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -87,10 +87,7 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
         ),
       ),
       elevation: 0,
-      iconTheme: IconThemeData(
-          color: Theme.of(context).brightness == Brightness.light
-              ? Theme.of(context).primaryColor
-              : Colors.white),
+      iconTheme: Theme.of(context).accentIconTheme,
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       titleSpacing: 0.0,
       title: ButtonTheme(
@@ -107,9 +104,7 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
             },
             child: SvgPicture.asset(
               'assets/images/logo_dark.svg',
-              color: Theme.of(context).brightness == Brightness.light
-                  ? Theme.of(context).primaryColor
-                  : Colors.white,
+              color: Theme.of(context).accentIconTheme.color,
               height: queryData.size.height / 25,
             ),
           )),

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -87,7 +87,10 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
         ),
       ),
       elevation: 0,
-      iconTheme: IconThemeData(color: Theme.of(context).primaryColor),
+      iconTheme: IconThemeData(
+          color: Theme.of(context).brightness == Brightness.light
+              ? Theme.of(context).primaryColor
+              : Colors.white),
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       titleSpacing: 0.0,
       title: ButtonTheme(
@@ -104,6 +107,9 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
             },
             child: SvgPicture.asset(
               'assets/images/logo_dark.svg',
+              color: Theme.of(context).brightness == Brightness.light
+                  ? Theme.of(context).primaryColor
+                  : Colors.white,
               height: queryData.size.height / 25,
             ),
           )),

--- a/app_feup/lib/view/Pages/general_page_view.dart
+++ b/app_feup/lib/view/Pages/general_page_view.dart
@@ -26,7 +26,7 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
   }
 
   /// Returns the current user image.
-  /// 
+  ///
   /// If the image is not found / doesn't exist returns a generic placeholder.
   DecorationImage getDecorageImage(File x) {
     final fallbackImage = decorageImage == null
@@ -54,10 +54,11 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
       },
       builder: (context, refresh) {
         return RefreshIndicator(
-            key: GlobalKey<RefreshIndicatorState>(),
-            child: child,
-            onRefresh: refresh,
-            color: Theme.of(context).accentColor);
+          key: GlobalKey<RefreshIndicatorState>(),
+          child: child,
+          onRefresh: refresh,
+          /* color: Theme.of(context).accentColor */
+        );
       },
     );
   }
@@ -71,7 +72,7 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
   }
 
   /// Builds the upper bar of the app.
-  /// 
+  ///
   /// This method returns an instance of `AppBar` containing the app's logo,
   /// an option button and a button with the user's picture.
   AppBar buildAppBar(BuildContext context) {
@@ -82,13 +83,13 @@ abstract class GeneralPageViewState extends State<StatefulWidget> {
         preferredSize: Size.zero,
         child: Container(
           margin: EdgeInsets.only(left: borderMargin, right: borderMargin),
-          color: Theme.of(context).dividerColor,
+          // color: Theme.of(context).dividerColor,
           height: 1.5,
         ),
       ),
       elevation: 0,
-      iconTheme: IconThemeData(color: Theme.of(context).accentColor),
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+      // iconTheme: IconThemeData(color: Theme.of(context).accentColor),
+      // backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       titleSpacing: 0.0,
       title: ButtonTheme(
           minWidth: 0,

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -200,8 +200,12 @@ class _LoginPageViewState extends State<LoginPageView> {
   /// Creates the widget for the user to keep signed in (save his data).
   Widget createSaveDataCheckBox() {
     return CheckboxListTile(
-      activeColor: Colors.white,
-      checkColor: Theme.of(context).primaryColor,
+      activeColor: Theme.of(context).brightness == Brightness.light
+          ? Colors.white
+          : Colors.black54,
+      checkColor: Theme.of(context).brightness == Brightness.light
+          ? Theme.of(context).primaryColor
+          : Colors.white,
       value: _keepSignedIn,
       onChanged: _setKeepSignedIn,
       title: Text(

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -133,7 +133,7 @@ class _LoginPageViewState extends State<LoginPageView> {
           SizedBox(
               child: SvgPicture.asset(
                 'assets/images/logo_dark.svg',
-                // color: Colors.white,
+                color: Colors.white,
               ),
               width: 100.0),
         ]));
@@ -158,7 +158,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   /// Creates the widget for the username input.
   Widget createUsernameInput(BuildContext context) {
     return TextFormField(
-      style: TextStyle(/* color: Colors.white, */ fontSize: 20),
+      style: TextStyle(color: Colors.white, fontSize: 20),
       enableSuggestions: false,
       autocorrect: false,
       autofocus: false,
@@ -178,7 +178,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   /// Creates the widget for the password input.
   Widget createPasswordInput() {
     return TextFormField(
-        style: TextStyle(/* color: Colors.white, */ fontSize: 20),
+        style: TextStyle(color: Colors.white, fontSize: 20),
         enableSuggestions: false,
         autocorrect: false,
         autofocus: false,
@@ -200,14 +200,15 @@ class _LoginPageViewState extends State<LoginPageView> {
   /// Creates the widget for the user to keep signed in (save his data).
   Widget createSaveDataCheckBox() {
     return CheckboxListTile(
+      activeColor: Colors.white,
+      checkColor: Theme.of(context).primaryColor,
       value: _keepSignedIn,
       onChanged: _setKeepSignedIn,
       title: Text(
         'Manter sessão iniciada',
         textAlign: TextAlign.center,
         style: TextStyle(
-            /* color: Colors.white, */ fontSize: 17.0,
-            fontWeight: FontWeight.w300),
+            color: Colors.white, fontSize: 17.0, fontWeight: FontWeight.w300),
       ),
     );
   }
@@ -236,7 +237,7 @@ class _LoginPageViewState extends State<LoginPageView> {
           },
           child: Text('Entrar',
               style: TextStyle(
-                  //color: Theme.of(context).accentColor,
+                  color: Theme.of(context).primaryColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 20),
               textAlign: TextAlign.center),
@@ -279,13 +280,13 @@ class _LoginPageViewState extends State<LoginPageView> {
     return InputDecoration(
         hintStyle: TextStyle(color: Colors.white),
         errorStyle: TextStyle(
-            //color: Colors.white70,
-            ),
+          color: Colors.white70,
+        ),
         hintText: placeholder,
         contentPadding: EdgeInsets.fromLTRB(10.0, 10.0, 10.0, 10.0),
         border: UnderlineInputBorder(),
         focusedBorder: UnderlineInputBorder(
-            borderSide: BorderSide(/* color: Colors.white, */ width: 3)));
+            borderSide: BorderSide(color: Colors.white, width: 3)));
   }
 
   /// Decoration for the password field.
@@ -303,7 +304,7 @@ class _LoginPageViewState extends State<LoginPageView> {
             _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
           ),
           onPressed: _toggleObscurePasswordInput,
-          //color: Colors.white,
+          color: Colors.white,
         ));
   }
 
@@ -314,8 +315,8 @@ class _LoginPageViewState extends State<LoginPageView> {
         onTap: () {
           _showLoginDetails(context);
         },
-        //splashColor: Colors.transparent,
-        //highlightColor: Colors.transparent,
+        splashColor: Colors.transparent,
+        highlightColor: Colors.transparent,
         child: Container(
             padding: EdgeInsets.all(8),
             child: Text(
@@ -323,7 +324,7 @@ class _LoginPageViewState extends State<LoginPageView> {
               textAlign: TextAlign.center,
               style: TextStyle(
                   decoration: TextDecoration.underline,
-                  // color: Colors.white,
+                  color: Colors.white,
                   fontSize: 17.0,
                   fontWeight: FontWeight.w300),
             )));

--- a/app_feup/lib/view/Pages/login_page_view.dart
+++ b/app_feup/lib/view/Pages/login_page_view.dart
@@ -69,7 +69,7 @@ class _LoginPageViewState extends State<LoginPageView> {
 
     return Scaffold(
         backgroundColor: Theme.of(context).brightness == Brightness.light
-            ? Theme.of(context).accentColor
+            ? Theme.of(context).primaryColor
             : Theme.of(context).scaffoldBackgroundColor,
         body: WillPopScope(
             child: Padding(
@@ -133,7 +133,7 @@ class _LoginPageViewState extends State<LoginPageView> {
           SizedBox(
               child: SvgPicture.asset(
                 'assets/images/logo_dark.svg',
-                color: Colors.white,
+                // color: Colors.white,
               ),
               width: 100.0),
         ]));
@@ -158,7 +158,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   /// Creates the widget for the username input.
   Widget createUsernameInput(BuildContext context) {
     return TextFormField(
-      style: TextStyle(color: Colors.white, fontSize: 20),
+      style: TextStyle(/* color: Colors.white, */ fontSize: 20),
       enableSuggestions: false,
       autocorrect: false,
       autofocus: false,
@@ -178,7 +178,7 @@ class _LoginPageViewState extends State<LoginPageView> {
   /// Creates the widget for the password input.
   Widget createPasswordInput() {
     return TextFormField(
-        style: TextStyle(color: Colors.white, fontSize: 20),
+        style: TextStyle(/* color: Colors.white, */ fontSize: 20),
         enableSuggestions: false,
         autocorrect: false,
         autofocus: false,
@@ -206,7 +206,8 @@ class _LoginPageViewState extends State<LoginPageView> {
         'Manter sessão iniciada',
         textAlign: TextAlign.center,
         style: TextStyle(
-            color: Colors.white, fontSize: 17.0, fontWeight: FontWeight.w300),
+            /* color: Colors.white, */ fontSize: 17.0,
+            fontWeight: FontWeight.w300),
       ),
     );
   }
@@ -235,7 +236,7 @@ class _LoginPageViewState extends State<LoginPageView> {
           },
           child: Text('Entrar',
               style: TextStyle(
-                  color: Theme.of(context).accentColor,
+                  //color: Theme.of(context).accentColor,
                   fontWeight: FontWeight.w400,
                   fontSize: 20),
               textAlign: TextAlign.center),
@@ -278,13 +279,13 @@ class _LoginPageViewState extends State<LoginPageView> {
     return InputDecoration(
         hintStyle: TextStyle(color: Colors.white),
         errorStyle: TextStyle(
-          color: Colors.white70,
-        ),
+            //color: Colors.white70,
+            ),
         hintText: placeholder,
         contentPadding: EdgeInsets.fromLTRB(10.0, 10.0, 10.0, 10.0),
         border: UnderlineInputBorder(),
         focusedBorder: UnderlineInputBorder(
-            borderSide: BorderSide(color: Colors.white, width: 3)));
+            borderSide: BorderSide(/* color: Colors.white, */ width: 3)));
   }
 
   /// Decoration for the password field.
@@ -302,7 +303,7 @@ class _LoginPageViewState extends State<LoginPageView> {
             _obscurePasswordInput ? Icons.visibility : Icons.visibility_off,
           ),
           onPressed: _toggleObscurePasswordInput,
-          color: Colors.white,
+          //color: Colors.white,
         ));
   }
 
@@ -313,8 +314,8 @@ class _LoginPageViewState extends State<LoginPageView> {
         onTap: () {
           _showLoginDetails(context);
         },
-        splashColor: Colors.transparent,
-        highlightColor: Colors.transparent,
+        //splashColor: Colors.transparent,
+        //highlightColor: Colors.transparent,
         child: Container(
             padding: EdgeInsets.all(8),
             child: Text(
@@ -322,7 +323,7 @@ class _LoginPageViewState extends State<LoginPageView> {
               textAlign: TextAlign.center,
               style: TextStyle(
                   decoration: TextDecoration.underline,
-                  color: Colors.white,
+                  // color: Colors.white,
                   fontSize: 17.0,
                   fontWeight: FontWeight.w300),
             )));

--- a/app_feup/lib/view/Pages/schedule_page_view.dart
+++ b/app_feup/lib/view/Pages/schedule_page_view.dart
@@ -51,7 +51,6 @@ class SchedulePageView extends StatelessWidget {
     final List<Widget> tabs = <Widget>[];
     for (var i = 0; i < daysOfTheWeek.length; i++) {
       tabs.add(Container(
-        //color: Theme.of(context).backgroundColor,
         width: queryData.size.width * 1 / 3,
         child: Tab(key: Key('schedule-page-tab-$i'), text: daysOfTheWeek[i]),
       ));

--- a/app_feup/lib/view/Pages/schedule_page_view.dart
+++ b/app_feup/lib/view/Pages/schedule_page_view.dart
@@ -51,7 +51,7 @@ class SchedulePageView extends StatelessWidget {
     final List<Widget> tabs = <Widget>[];
     for (var i = 0; i < daysOfTheWeek.length; i++) {
       tabs.add(Container(
-        color: Theme.of(context).backgroundColor,
+        //color: Theme.of(context).backgroundColor,
         width: queryData.size.width * 1 / 3,
         child: Tab(key: Key('schedule-page-tab-$i'), text: daysOfTheWeek[i]),
       ));

--- a/app_feup/lib/view/Pages/splash_page_view.dart
+++ b/app_feup/lib/view/Pages/splash_page_view.dart
@@ -38,8 +38,7 @@ class _SplashScreenState extends State<SplashScreen> {
         fit: StackFit.expand,
         children: <Widget>[
           Container(
-            decoration: BoxDecoration(
-                /* color: applicationLightTheme.backgroundColor */),
+            decoration: BoxDecoration(),
           ),
           Column(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -77,7 +76,7 @@ class _SplashScreenState extends State<SplashScreen> {
         child: SizedBox(
             child: SvgPicture.asset(
               'assets/images/logo_dark.svg',
-              // color: Theme.of(context).accentColor,
+              color: Theme.of(context).primaryColor,
             ),
             width: 150.0));
   }
@@ -86,7 +85,7 @@ class _SplashScreenState extends State<SplashScreen> {
   Widget createNILogo() {
     return SvgPicture.asset(
       'assets/images/by_niaefeup.svg',
-      // color: Theme.of(context).accentColor,
+      color: Theme.of(context).primaryColor,
       width: queryData.size.width * 0.45,
     );
   }

--- a/app_feup/lib/view/Pages/splash_page_view.dart
+++ b/app_feup/lib/view/Pages/splash_page_view.dart
@@ -10,7 +10,6 @@ import 'package:uni/model/app_state.dart';
 import 'package:uni/redux/action_creators.dart';
 import 'package:uni/view/Pages/login_page_view.dart';
 import 'package:uni/view/Widgets/terms_and_condition_dialog.dart';
-import 'package:uni/view/theme.dart';
 
 import 'home_page_view.dart';
 import 'logout_route.dart';

--- a/app_feup/lib/view/Pages/splash_page_view.dart
+++ b/app_feup/lib/view/Pages/splash_page_view.dart
@@ -38,8 +38,8 @@ class _SplashScreenState extends State<SplashScreen> {
         fit: StackFit.expand,
         children: <Widget>[
           Container(
-            decoration:
-                BoxDecoration(color: applicationLightTheme.backgroundColor),
+            decoration: BoxDecoration(
+                /* color: applicationLightTheme.backgroundColor */),
           ),
           Column(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -77,7 +77,7 @@ class _SplashScreenState extends State<SplashScreen> {
         child: SizedBox(
             child: SvgPicture.asset(
               'assets/images/logo_dark.svg',
-              color: Theme.of(context).accentColor,
+              // color: Theme.of(context).accentColor,
             ),
             width: 150.0));
   }
@@ -86,7 +86,7 @@ class _SplashScreenState extends State<SplashScreen> {
   Widget createNILogo() {
     return SvgPicture.asset(
       'assets/images/by_niaefeup.svg',
-      color: Theme.of(context).accentColor,
+      // color: Theme.of(context).accentColor,
       width: queryData.size.width * 0.45,
     );
   }

--- a/app_feup/lib/view/Widgets/account_info_card.dart
+++ b/app_feup/lib/view/Widgets/account_info_card.dart
@@ -25,10 +25,7 @@ class AccountInfoCard extends GenericCard {
                 margin:
                     const EdgeInsets.only(top: 20.0, bottom: 8.0, left: 20.0),
                 child: Text('Saldo: ',
-                    style: Theme.of(context)
-                        .textTheme
-                        .headline4
-                        .apply(fontSizeDelta: -4)),
+                    style: Theme.of(context).textTheme.subtitle2),
               ),
               Container(
                 margin:
@@ -44,10 +41,7 @@ class AccountInfoCard extends GenericCard {
                 margin:
                     const EdgeInsets.only(top: 8.0, bottom: 20.0, left: 20.0),
                 child: Text('Data limite próxima prestação: ',
-                    style: Theme.of(context)
-                        .textTheme
-                        .headline4
-                        .apply(fontSizeDelta: -4)),
+                    style: Theme.of(context).textTheme.subtitle2),
               ),
               Container(
                 margin:

--- a/app_feup/lib/view/Widgets/back_button_exit_wrapper.dart
+++ b/app_feup/lib/view/Widgets/back_button_exit_wrapper.dart
@@ -16,7 +16,7 @@ class BackButtonExitWrapper extends StatelessWidget {
     return showDialog(
             context: context,
             builder: (context) => AlertDialog(
-                  title: Text('Tens a certeza que pretendes sair?'),
+                  title: Text('Tens a certeza de que pretendes sair?'),
                   actions: <Widget>[
                     ElevatedButton(
                       onPressed: () => Navigator.of(context).pop(false),

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -143,7 +143,8 @@ class BugReportFormState extends State<BugReportForm> {
       padding: EdgeInsets.only(bottom: 20),
       child: Center(
         child: Text(
-            '''Encontraste algum bug na aplicação?\nTens alguma sugestão para a app?\nConta-nos para que possamos melhorar!''',
+            '''Encontraste algum bug na aplicação?\nTens alguma '''
+            '''sugestão para a app?\nConta-nos para que possamos melhorar!''',
             style: Theme.of(context).textTheme.bodyText2,
             textAlign: TextAlign.center),
       ),

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -121,20 +121,14 @@ class BugReportFormState extends State<BugReportForm> {
         margin: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20),
         child: Row(
           children: <Widget>[
-            Icon(
-              Icons.bug_report,
-              /* color: Theme.of(context).accentColor, size: 50.0 */
-            ),
+            Icon(Icons.bug_report, size: 50.0),
             Expanded(
                 child: Text(
               'Bugs e Sugestões',
               textScaleFactor: 1.6,
               textAlign: TextAlign.center,
             )),
-            Icon(
-              Icons.bug_report,
-              /* color: Theme.of(context).accentColor, size: 50.0 */
-            ),
+            Icon(Icons.bug_report, size: 50.0),
           ],
         ));
   }
@@ -174,7 +168,6 @@ class BugReportFormState extends State<BugReportForm> {
                 margin: EdgeInsets.only(right: 15),
                 child: Icon(
                   Icons.bug_report,
-                  //color: Theme.of(context).accentColor,
                 )),
             Expanded(
                 child: DropdownButton(

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -136,10 +136,7 @@ class BugReportFormState extends State<BugReportForm> {
   /// Returns a widget for the overview text of the bug report form
   Widget bugReportIntro(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(
-          /* border: Border(
-              bottom: BorderSide(color: Theme.of(context).dividerColor)) */
-          ),
+      decoration: BoxDecoration(),
       padding: EdgeInsets.only(bottom: 20),
       child: Center(
         child: Text(

--- a/app_feup/lib/view/Widgets/bug_report_form.dart
+++ b/app_feup/lib/view/Widgets/bug_report_form.dart
@@ -121,16 +121,20 @@ class BugReportFormState extends State<BugReportForm> {
         margin: EdgeInsets.symmetric(vertical: 10.0, horizontal: 20),
         child: Row(
           children: <Widget>[
-            Icon(Icons.bug_report,
-                color: Theme.of(context).accentColor, size: 50.0),
+            Icon(
+              Icons.bug_report,
+              /* color: Theme.of(context).accentColor, size: 50.0 */
+            ),
             Expanded(
                 child: Text(
               'Bugs e Sugestões',
               textScaleFactor: 1.6,
               textAlign: TextAlign.center,
             )),
-            Icon(Icons.bug_report,
-                color: Theme.of(context).accentColor, size: 50.0),
+            Icon(
+              Icons.bug_report,
+              /* color: Theme.of(context).accentColor, size: 50.0 */
+            ),
           ],
         ));
   }
@@ -139,8 +143,9 @@ class BugReportFormState extends State<BugReportForm> {
   Widget bugReportIntro(BuildContext context) {
     return Container(
       decoration: BoxDecoration(
-          border: Border(
-              bottom: BorderSide(color: Theme.of(context).dividerColor))),
+          /* border: Border(
+              bottom: BorderSide(color: Theme.of(context).dividerColor)) */
+          ),
       padding: EdgeInsets.only(bottom: 20),
       child: Center(
         child: Text(
@@ -169,7 +174,7 @@ class BugReportFormState extends State<BugReportForm> {
                 margin: EdgeInsets.only(right: 15),
                 child: Icon(
                   Icons.bug_report,
-                  color: Theme.of(context).accentColor,
+                  //color: Theme.of(context).accentColor,
                 )),
             Expanded(
                 child: DropdownButton(

--- a/app_feup/lib/view/Widgets/bus_stop_card.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_card.dart
@@ -88,10 +88,8 @@ class BusStopCard extends GenericCard {
           Container(
               padding: EdgeInsets.all(8.0),
               child: Text('Não foi possível obter informação',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(color: Theme.of(context).accentColor)))
+                  style: Theme.of(context).textTheme.headline4
+                  /* .apply(color: Theme.of(context).accentColor) */))
         ]);
         break;
     }
@@ -103,10 +101,8 @@ class BusStopCard extends GenericCard {
       children: <Widget>[
         Icon(Icons.directions_bus), // color lightgrey
         Text('STCP - Próximas Viagens',
-            style: Theme.of(context)
-                .textTheme
-                .headline4
-                .apply(color: Theme.of(context).accentColor)),
+            style: Theme.of(context).textTheme.headline4
+            /* .apply(color: Theme.of(context).accentColor) */),
       ],
     );
   }

--- a/app_feup/lib/view/Widgets/bus_stop_card.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_card.dart
@@ -59,7 +59,7 @@ class BusStopCard extends GenericCard {
                       overflow: TextOverflow.ellipsis,
                       style: Theme.of(context)
                           .textTheme
-                          .headline4
+                          .subtitle2
                           .apply(color: Theme.of(context).accentColor)),
                   IconButton(
                     icon: Icon(Icons.settings),

--- a/app_feup/lib/view/Widgets/bus_stop_card.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_card.dart
@@ -57,10 +57,7 @@ class BusStopCard extends GenericCard {
                   Text('Configura os teus autocarros',
                       maxLines: 1,
                       overflow: TextOverflow.ellipsis,
-                      style: Theme.of(context)
-                          .textTheme
-                          .subtitle2
-                          .apply(color: Theme.of(context).accentColor)),
+                      style: Theme.of(context).textTheme.subtitle2.apply()),
                   IconButton(
                     icon: Icon(Icons.settings),
                     onPressed: () => Navigator.push(
@@ -88,8 +85,7 @@ class BusStopCard extends GenericCard {
           Container(
               padding: EdgeInsets.all(8.0),
               child: Text('Não foi possível obter informação',
-                  style: Theme.of(context).textTheme.headline4
-                  /* .apply(color: Theme.of(context).accentColor) */))
+                  style: Theme.of(context).textTheme.subtitle1))
         ]);
         break;
     }
@@ -101,8 +97,7 @@ class BusStopCard extends GenericCard {
       children: <Widget>[
         Icon(Icons.directions_bus), // color lightgrey
         Text('STCP - Próximas Viagens',
-            style: Theme.of(context).textTheme.headline4
-            /* .apply(color: Theme.of(context).accentColor) */),
+            style: Theme.of(context).textTheme.subtitle1),
       ],
     );
   }

--- a/app_feup/lib/view/Widgets/bus_stop_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_row.dart
@@ -50,15 +50,15 @@ class BusStopRow extends StatelessWidget {
     return Text('Não há viagens planeadas de momento.',
         maxLines: 3,
         overflow: TextOverflow.ellipsis,
-        style: Theme.of(context).textTheme.headline4);
+        style: Theme.of(context).textTheme.subtitle1);
   }
 
   Widget stopCodeRotatedContainer(context) {
     return Container(
       padding: EdgeInsets.only(left: 4.0),
       child: RotatedBox(
-        child: Text(this.stopCode, style: Theme.of(context).textTheme.headline4
-            /* .apply(color: Theme.of(context).accentColor) */),
+        child:
+            Text(this.stopCode, style: Theme.of(context).textTheme.subtitle1),
         quarterTurns: 3,
       ),
     );

--- a/app_feup/lib/view/Widgets/bus_stop_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_row.dart
@@ -57,11 +57,8 @@ class BusStopRow extends StatelessWidget {
     return Container(
       padding: EdgeInsets.only(left: 4.0),
       child: RotatedBox(
-        child: Text(this.stopCode,
-            style: Theme.of(context)
-                .textTheme
-                .headline4
-                .apply(color: Theme.of(context).accentColor)),
+        child: Text(this.stopCode, style: Theme.of(context).textTheme.headline4
+            /* .apply(color: Theme.of(context).accentColor) */),
         quarterTurns: 3,
       ),
     );
@@ -75,13 +72,16 @@ class BusStopRow extends StatelessWidget {
           padding: EdgeInsets.all(12.0), child: TripRow(trip: trips[0])));
     } else {
       for (int i = 0; i < trips.length; i++) {
-        Color color = Theme.of(context).accentColor;
-        if (i == trips.length - 1) color = Colors.transparent;
+/*         Color color = Theme.of(context).accentColor;
+        if (i == trips.length - 1) color = Colors.transparent; */
 
         tripRows.add(Container(
             padding: EdgeInsets.all(12.0),
             decoration: BoxDecoration(
-                border: Border(bottom: BorderSide(width: 0.1, color: color))),
+                border: Border(
+                    bottom: BorderSide(
+              width: 0.1, /* color: color */
+            ))),
             child: TripRow(trip: trips[i])));
       }
     }

--- a/app_feup/lib/view/Widgets/bus_stop_selection_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_selection_row.dart
@@ -47,7 +47,6 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
                   left: width * 0.20,
                   right: width * 0.20),
               child: RowContainer(
-                  // borderColor: Theme.of(context).accentColor,
                   child: Container(
                       padding: EdgeInsets.only(left: 10.0, right: 10.0),
                       child: Row(
@@ -64,7 +63,6 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
                                   onTap: () => toggleFavorite(context)),
                               IconButton(
                                 icon: Icon(Icons.cancel),
-                                //color: Theme.of(context).buttonColor,
                                 onPressed: () {
                                   deleteStop(context);
                                 },

--- a/app_feup/lib/view/Widgets/bus_stop_selection_row.dart
+++ b/app_feup/lib/view/Widgets/bus_stop_selection_row.dart
@@ -47,7 +47,7 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
                   left: width * 0.20,
                   right: width * 0.20),
               child: RowContainer(
-                  borderColor: Theme.of(context).accentColor,
+                  // borderColor: Theme.of(context).accentColor,
                   child: Container(
                       padding: EdgeInsets.only(left: 10.0, right: 10.0),
                       child: Row(
@@ -64,7 +64,7 @@ class BusStopSelectionRowState extends State<BusStopSelectionRow> {
                                   onTap: () => toggleFavorite(context)),
                               IconButton(
                                 icon: Icon(Icons.cancel),
-                                color: Theme.of(context).buttonColor,
+                                //color: Theme.of(context).buttonColor,
                                 onPressed: () {
                                   deleteStop(context);
                                 },

--- a/app_feup/lib/view/Widgets/course_info_card.dart
+++ b/app_feup/lib/view/Widgets/course_info_card.dart
@@ -20,10 +20,7 @@ class CourseInfoCard extends GenericCard {
             Container(
               margin: const EdgeInsets.only(top: 20.0, bottom: 8.0, left: 20.0),
               child: Text('Ano curricular atual: ',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(fontSizeDelta: -4)),
+                  style: Theme.of(context).textTheme.subtitle2),
             ),
             Container(
               margin:
@@ -35,10 +32,7 @@ class CourseInfoCard extends GenericCard {
             Container(
               margin: const EdgeInsets.only(top: 10.0, bottom: 8.0, left: 20.0),
               child: Text('Estado atual: ',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(fontSizeDelta: -4)),
+                  style: Theme.of(context).textTheme.subtitle2),
             ),
             Container(
               margin:
@@ -51,10 +45,7 @@ class CourseInfoCard extends GenericCard {
               margin:
                   const EdgeInsets.only(top: 10.0, bottom: 20.0, left: 20.0),
               child: Text('Ano da primeira inscrição: ',
-                  style: Theme.of(context)
-                      .textTheme
-                      .headline4
-                      .apply(fontSizeDelta: -4)),
+                  style: Theme.of(context).textTheme.subtitle2),
             ),
             Container(
                 margin:

--- a/app_feup/lib/view/Widgets/estimated_arrival_timestamp.dart
+++ b/app_feup/lib/view/Widgets/estimated_arrival_timestamp.dart
@@ -31,6 +31,6 @@ class EstimatedArrivalTimeStamp extends StatelessWidget {
     num = estimatedTime.minute;
     final String minute = (num >= 10 ? '$num' : '0$num');
 
-    return Text('$hour:$minute', style: Theme.of(context).textTheme.headline4);
+    return Text('$hour:$minute', style: Theme.of(context).textTheme.subtitle1);
   }
 }

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -96,9 +96,9 @@ class ExamCard extends GenericCard {
       DateRectangle(date: exam.weekDay + ', ' + exam.day + ' de ' + exam.month),
       Container(
         child: RowContainer(
-/*           color: isHighlighted(exam)
+          color: isHighlighted(exam)
               ? Theme.of(context).backgroundColor
-              : Theme.of(context).hintColor, */
+              : Theme.of(context).hintColor,
           child: ScheduleRow(
             subject: exam.subject,
             rooms: exam.rooms,
@@ -118,8 +118,8 @@ class ExamCard extends GenericCard {
       margin: EdgeInsets.only(top: 8),
       child: RowContainer(
         color: isHighlighted(exam)
-            ? Theme.of(context).scaffoldBackgroundColor
-            : Colors.white,
+            ? Theme.of(context).backgroundColor
+            : Theme.of(context).hintColor,
         child: Container(
           padding: EdgeInsets.all(11),
           child: Row(

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -53,7 +53,7 @@ class ExamCard extends GenericCard {
         contentChecker: examsInfo.item1 != null && examsInfo.item1.isNotEmpty,
         onNullContent: Center(
           child: Text('Não existem exames para apresentar',
-              style: Theme.of(context).textTheme.headline4),
+              style: Theme.of(context).textTheme.headline6),
         ),
       ),
     );
@@ -80,8 +80,7 @@ class ExamCard extends GenericCard {
         decoration: BoxDecoration(
             border: Border(
                 bottom: BorderSide(
-          width: 1.5, /* color: Theme.of(context).dividerColor */
-        ))),
+                    width: 1.5, color: Theme.of(context).dividerColor))),
       ));
     }
     for (int i = 1; i < 4 && i < exams.length; i++) {
@@ -118,9 +117,9 @@ class ExamCard extends GenericCard {
     return Container(
       margin: EdgeInsets.only(top: 8),
       child: RowContainer(
-/*         color: isHighlighted(exam)
-            ? Theme.of(context).backgroundColor
-            : Theme.of(context).hintColor, */
+        color: isHighlighted(exam)
+            ? Theme.of(context).scaffoldBackgroundColor
+            : Colors.white,
         child: Container(
           padding: EdgeInsets.all(11),
           child: Row(
@@ -129,8 +128,8 @@ class ExamCard extends GenericCard {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
                 Text(
-                  exam.day + '/' + exam.month,
-                  style: Theme.of(context).textTheme.headline4,
+                  exam.day + ' de ' + exam.month,
+                  style: Theme.of(context).textTheme.bodyText1,
                 ),
                 ScheduleEventRectangle(
                     subject: exam.subject,

--- a/app_feup/lib/view/Widgets/exam_card.dart
+++ b/app_feup/lib/view/Widgets/exam_card.dart
@@ -80,7 +80,8 @@ class ExamCard extends GenericCard {
         decoration: BoxDecoration(
             border: Border(
                 bottom: BorderSide(
-                    width: 1.5, color: Theme.of(context).dividerColor))),
+          width: 1.5, /* color: Theme.of(context).dividerColor */
+        ))),
       ));
     }
     for (int i = 1; i < 4 && i < exams.length; i++) {
@@ -96,9 +97,9 @@ class ExamCard extends GenericCard {
       DateRectangle(date: exam.weekDay + ', ' + exam.day + ' de ' + exam.month),
       Container(
         child: RowContainer(
-          color: isHighlighted(exam)
+/*           color: isHighlighted(exam)
               ? Theme.of(context).backgroundColor
-              : Theme.of(context).hintColor,
+              : Theme.of(context).hintColor, */
           child: ScheduleRow(
             subject: exam.subject,
             rooms: exam.rooms,
@@ -117,9 +118,9 @@ class ExamCard extends GenericCard {
     return Container(
       margin: EdgeInsets.only(top: 8),
       child: RowContainer(
-        color: isHighlighted(exam)
+/*         color: isHighlighted(exam)
             ? Theme.of(context).backgroundColor
-            : Theme.of(context).hintColor,
+            : Theme.of(context).hintColor, */
         child: Container(
           padding: EdgeInsets.all(11),
           child: Row(

--- a/app_feup/lib/view/Widgets/exam_page_title_filter.dart
+++ b/app_feup/lib/view/Widgets/exam_page_title_filter.dart
@@ -17,8 +17,7 @@ class ExamPageTitleFilter extends StatelessWidget {
         children: [
           Text(
             name,
-            style:
-                Theme.of(context).textTheme.headline6.apply(fontSizeDelta: 7),
+            style: Theme.of(context).textTheme.headline4,
           ),
           Material(child: ExamFilterMenu()),
         ],

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -45,7 +45,7 @@ class FormTextField extends StatelessWidget {
                 margin: EdgeInsets.only(right: 15),
                 child: Icon(
                   icon,
-                  color: Theme.of(context).accentColor,
+                  //color: Theme.of(context).accentColor,
                 )),
             Expanded(
                 child: TextFormField(
@@ -54,8 +54,8 @@ class FormTextField extends StatelessWidget {
               maxLines: maxLines,
               decoration: InputDecoration(
                 focusedBorder: UnderlineInputBorder(
-                  borderSide: BorderSide(color: Theme.of(context).accentColor),
-                ),
+                    //borderSide: BorderSide(color: Theme.of(context).accentColor),
+                    ),
                 hintText: hintText,
                 hintStyle: Theme.of(context).textTheme.bodyText2,
                 labelText: labelText,

--- a/app_feup/lib/view/Widgets/form_text_field.dart
+++ b/app_feup/lib/view/Widgets/form_text_field.dart
@@ -45,7 +45,6 @@ class FormTextField extends StatelessWidget {
                 margin: EdgeInsets.only(right: 15),
                 child: Icon(
                   icon,
-                  //color: Theme.of(context).accentColor,
                 )),
             Expanded(
                 child: TextFormField(
@@ -53,9 +52,7 @@ class FormTextField extends StatelessWidget {
               minLines: minLines,
               maxLines: maxLines,
               decoration: InputDecoration(
-                focusedBorder: UnderlineInputBorder(
-                    //borderSide: BorderSide(color: Theme.of(context).accentColor),
-                    ),
+                focusedBorder: UnderlineInputBorder(),
                 hintText: hintText,
                 hintStyle: Theme.of(context).textTheme.bodyText2,
                 labelText: labelText,

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -75,9 +75,7 @@ class GenericCardState extends State<GenericCard> {
                 ),
                 child: Container(
                   decoration: BoxDecoration(
-                      color: Theme.of(context).brightness == Brightness.light
-                          ? Colors.white
-                          : Colors.black,
+                      color: Theme.of(context).cardColor,
                       borderRadius:
                           BorderRadius.all(Radius.circular(this.borderRadius))),
                   width: (double.infinity),
@@ -93,10 +91,7 @@ class GenericCardState extends State<GenericCard> {
                                     .textTheme
                                     .headline5
                                     .apply(
-                                        color: Theme.of(context).brightness ==
-                                                Brightness.light
-                                            ? Theme.of(context).primaryColor
-                                            : Colors.white)),
+                                        color: Theme.of(context).primaryColor)),
                             alignment: Alignment.centerLeft,
                             padding: EdgeInsets.symmetric(horizontal: 15),
                             margin: EdgeInsets.only(top: 15, bottom: 10),

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -59,11 +59,11 @@ class GenericCardState extends State<GenericCard> {
               decoration: BoxDecoration(
                   boxShadow: [
                     BoxShadow(
-                        color: Color.fromARGB(0x1c, 0, 0, 0),
+                        // color: Color.fromARGB(0x1c, 0, 0, 0),
                         blurRadius: 7.0,
                         offset: Offset(0.0, 1.0))
                   ],
-                  color: Theme.of(context).dividerColor,
+                  //color: Theme.of(context).dividerColor,
                   borderRadius:
                       BorderRadius.all(Radius.circular(this.borderRadius))),
               child: ConstrainedBox(
@@ -72,7 +72,7 @@ class GenericCardState extends State<GenericCard> {
                 ),
                 child: Container(
                   decoration: BoxDecoration(
-                      color: Theme.of(context).primaryColor,
+                      //color: Theme.of(context).primaryColor,
                       borderRadius:
                           BorderRadius.all(Radius.circular(this.borderRadius))),
                   width: (double.infinity),

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -28,7 +28,11 @@ abstract class GenericCard extends StatefulWidget {
 
   Text getInfoText(String text, BuildContext context) {
     return Text(text == null ? 'N/A' : text,
-        textAlign: TextAlign.end, style: Theme.of(context).textTheme.headline3);
+        textAlign: TextAlign.end,
+        style: Theme.of(context)
+            .textTheme
+            .headline6
+            .apply(color: Theme.of(context).accentColor));
   }
 
   showLastRefreshedTime(time, context) {
@@ -59,11 +63,10 @@ class GenericCardState extends State<GenericCard> {
               decoration: BoxDecoration(
                   boxShadow: [
                     BoxShadow(
-                        // color: Color.fromARGB(0x1c, 0, 0, 0),
+                        color: Color.fromARGB(0x1c, 0, 0, 0),
                         blurRadius: 7.0,
                         offset: Offset(0.0, 1.0))
                   ],
-                  //color: Theme.of(context).dividerColor,
                   borderRadius:
                       BorderRadius.all(Radius.circular(this.borderRadius))),
               child: ConstrainedBox(
@@ -72,7 +75,9 @@ class GenericCardState extends State<GenericCard> {
                 ),
                 child: Container(
                   decoration: BoxDecoration(
-                      //color: Theme.of(context).primaryColor,
+                      color: Theme.of(context).brightness == Brightness.light
+                          ? Colors.white
+                          : Colors.black,
                       borderRadius:
                           BorderRadius.all(Radius.circular(this.borderRadius))),
                   width: (double.infinity),
@@ -86,10 +91,9 @@ class GenericCardState extends State<GenericCard> {
                             child: Text(widget.getTitle(),
                                 style: Theme.of(context)
                                     .textTheme
-                                    .headline1
+                                    .headline5
                                     .apply(
-                                        fontSizeDelta: -53,
-                                        fontWeightDelta: -3)),
+                                        color: Theme.of(context).primaryColor)),
                             alignment: Alignment.centerLeft,
                             padding: EdgeInsets.symmetric(horizontal: 15),
                             margin: EdgeInsets.only(top: 15, bottom: 10),

--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -93,7 +93,10 @@ class GenericCardState extends State<GenericCard> {
                                     .textTheme
                                     .headline5
                                     .apply(
-                                        color: Theme.of(context).primaryColor)),
+                                        color: Theme.of(context).brightness ==
+                                                Brightness.light
+                                            ? Theme.of(context).primaryColor
+                                            : Colors.white)),
                             alignment: Alignment.centerLeft,
                             padding: EdgeInsets.symmetric(horizontal: 15),
                             margin: EdgeInsets.only(top: 15, bottom: 10),

--- a/app_feup/lib/view/Widgets/last_update_timestamp.dart
+++ b/app_feup/lib/view/Widgets/last_update_timestamp.dart
@@ -29,7 +29,7 @@ class LastUpdateTimeStamp extends StatelessWidget {
           Text(
               'Atualizado há $lastUpdateMinutes minuto' +
                   (lastUpdateMinutes != 1 ? 's' : ''),
-              style: Theme.of(context).textTheme.headline4)
+              style: Theme.of(context).textTheme.subtitle2)
         ]);
   }
 }

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -117,8 +117,7 @@ class MainCardsList extends StatelessWidget {
       child: Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
         Text(
           Constants.navPersonalArea,
-          style:
-              Theme.of(context).textTheme.headline6.apply(fontSizeFactor: 1.3),
+          style: Theme.of(context).textTheme.headline4,
         ),
         GestureDetector(
             onTap: () => StoreProvider.of<AppState>(context)

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -80,9 +80,10 @@ class MainCardsList extends StatelessWidget {
               Navigator.pop(context);
             },
           ),
-          decoration: BoxDecoration(
-              border: Border(
-                  bottom: BorderSide(color: Theme.of(context).dividerColor))),
+          decoration: BoxDecoration()
+          /* border: Border(
+                  bottom: BorderSide(color: Theme.of(context).dividerColor))) */
+          ,
         ));
       }
     });

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -80,10 +80,7 @@ class MainCardsList extends StatelessWidget {
               Navigator.pop(context);
             },
           ),
-          decoration: BoxDecoration()
-          /* border: Border(
-                  bottom: BorderSide(color: Theme.of(context).dividerColor))) */
-          ,
+          decoration: BoxDecoration(),
         ));
       }
     });

--- a/app_feup/lib/view/Widgets/navigation_drawer.dart
+++ b/app_feup/lib/view/Widgets/navigation_drawer.dart
@@ -59,12 +59,10 @@ class NavigationDrawerState extends State<NavigationDrawer> {
 
   Decoration _getSelectionDecoration(String name) {
     return (name == getCurrentRoute())
-        ? BoxDecoration(
-            border: Border(
-                left: BorderSide(
-                    color: Theme.of(context).accentColor, width: 3.0)),
-            color: Theme.of(context).dividerColor,
-          )
+        ? BoxDecoration(border: Border(left: BorderSide())
+            //color: Theme.of(context).accentColor, width: 3.0)),
+            //color: Theme.of(context).dividerColor,
+            )
         : null;
   }
 
@@ -76,13 +74,11 @@ class NavigationDrawerState extends State<NavigationDrawer> {
         padding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 5.0),
       ),
       child: Container(
-        padding: const EdgeInsets.all(15.0),
-        child: Text(Constants.navLogOut,
-            style: Theme.of(context)
-                .textTheme
-                .headline6
-                .apply(color: Theme.of(context).accentColor)),
-      ),
+          padding: const EdgeInsets.all(15.0),
+          child: Text(Constants.navLogOut,
+              style: Theme.of(context).textTheme.headline6)
+          //.apply(color: Theme.of(context).accentColor)),
+          ),
     );
   }
 
@@ -112,7 +108,7 @@ class NavigationDrawerState extends State<NavigationDrawer> {
             child: Text(d,
                 style: TextStyle(
                     fontSize: 18.0,
-                    color: Theme.of(context).accentColor,
+                    //color: Theme.of(context).accentColor,
                     fontWeight: FontWeight.normal)),
           ),
           dense: true,

--- a/app_feup/lib/view/Widgets/navigation_drawer.dart
+++ b/app_feup/lib/view/Widgets/navigation_drawer.dart
@@ -59,10 +59,12 @@ class NavigationDrawerState extends State<NavigationDrawer> {
 
   Decoration _getSelectionDecoration(String name) {
     return (name == getCurrentRoute())
-        ? BoxDecoration(border: Border(left: BorderSide())
-            //color: Theme.of(context).accentColor, width: 3.0)),
-            //color: Theme.of(context).dividerColor,
-            )
+        ? BoxDecoration(
+            border: Border(
+                left: BorderSide(
+                    color: Theme.of(context).primaryColor, width: 3.0)),
+            color: Theme.of(context).dividerColor,
+          )
         : null;
   }
 
@@ -74,11 +76,13 @@ class NavigationDrawerState extends State<NavigationDrawer> {
         padding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 5.0),
       ),
       child: Container(
-          padding: const EdgeInsets.all(15.0),
-          child: Text(Constants.navLogOut,
-              style: Theme.of(context).textTheme.headline6)
-          //.apply(color: Theme.of(context).accentColor)),
-          ),
+        padding: const EdgeInsets.all(15.0),
+        child: Text(Constants.navLogOut,
+            style: Theme.of(context)
+                .textTheme
+                .headline6
+                .apply(color: Theme.of(context).primaryColor)),
+      ),
     );
   }
 
@@ -108,7 +112,7 @@ class NavigationDrawerState extends State<NavigationDrawer> {
             child: Text(d,
                 style: TextStyle(
                     fontSize: 18.0,
-                    //color: Theme.of(context).accentColor,
+                    color: Theme.of(context).primaryColor,
                     fontWeight: FontWeight.normal)),
           ),
           dense: true,

--- a/app_feup/lib/view/Widgets/page_title.dart
+++ b/app_feup/lib/view/Widgets/page_title.dart
@@ -4,19 +4,16 @@ import 'package:flutter/widgets.dart';
 class PageTitle extends StatelessWidget {
   final String name;
 
-  const PageTitle({
-    Key key,
-    @required this.name
-  }) : super(key: key);
+  const PageTitle({Key key, @required this.name}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
+    return Container(
       padding: EdgeInsets.fromLTRB(20, 20, 20, 10),
       alignment: Alignment.center,
-      child:  Text(
+      child: Text(
         name,
-        style: Theme.of(context).textTheme.headline6.apply(fontSizeDelta: 7),
+        style: Theme.of(context).textTheme.headline4,
       ),
     );
   }

--- a/app_feup/lib/view/Widgets/print_info_card.dart
+++ b/app_feup/lib/view/Widgets/print_info_card.dart
@@ -12,7 +12,7 @@ class PrintInfoCard extends GenericCard {
 
   @override
   Widget buildCardContent(BuildContext context) {
-    return  Column(
+    return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         Table(
@@ -24,10 +24,7 @@ class PrintInfoCard extends GenericCard {
                   margin: const EdgeInsets.only(
                       top: 20.0, bottom: 20.0, left: 20.0),
                   child: Text('Valor disponível: ',
-                      style: Theme.of(context)
-                          .textTheme
-                          .headline4
-                          .apply(fontSizeDelta: -4)),
+                      style: Theme.of(context).textTheme.subtitle2),
                 ),
                 Container(
                   margin: const EdgeInsets.only(

--- a/app_feup/lib/view/Widgets/request_dependent_widget_builder.dart
+++ b/app_feup/lib/view/Widgets/request_dependent_widget_builder.dart
@@ -5,16 +5,16 @@ import 'package:uni/controller/local_storage/app_last_user_info_update_database.
 import 'package:uni/model/app_state.dart';
 
 class RequestDependentWidgetBuilder extends StatelessWidget {
-  const RequestDependentWidgetBuilder({
-    Key key,
-    @required this.context,
-    @required this.status,
-    @required this.contentGenerator,
-    @required this.content,
-    @required this.contentChecker,
-    @required this.onNullContent,
-    this.index
-  }) : super(key: key);
+  const RequestDependentWidgetBuilder(
+      {Key key,
+      @required this.context,
+      @required this.status,
+      @required this.contentGenerator,
+      @required this.content,
+      @required this.contentChecker,
+      @required this.onNullContent,
+      this.index})
+      : super(key: key);
 
   final BuildContext context;
   final RequestStatus status;
@@ -53,7 +53,7 @@ class RequestDependentWidgetBuilder extends StatelessWidget {
                 : Center(
                     child: Text(
                         '''Erro de comunicação. Por favor verifica a tua ligação à internet.''',
-                        style: Theme.of(context).textTheme.headline4));
+                        style: Theme.of(context).textTheme.subtitle1));
         }
       },
     );

--- a/app_feup/lib/view/Widgets/row_container.dart
+++ b/app_feup/lib/view/Widgets/row_container.dart
@@ -12,11 +12,11 @@ class RowContainer extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
           border: Border.all(
-              /* color: borderColor == null
+              color: borderColor == null
                   ? Theme.of(context).dividerColor
-                  : this.borderColor, */
+                  : this.borderColor,
               width: 0.5),
-          /* color: this.color, */
+          color: this.color,
           borderRadius: BorderRadius.all(Radius.circular(7))),
       child: this.child,
     );

--- a/app_feup/lib/view/Widgets/row_container.dart
+++ b/app_feup/lib/view/Widgets/row_container.dart
@@ -12,11 +12,11 @@ class RowContainer extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
           border: Border.all(
-              color: borderColor == null
+              /* color: borderColor == null
                   ? Theme.of(context).dividerColor
-                  : this.borderColor,
+                  : this.borderColor, */
               width: 0.5),
-          color: this.color,
+          /* color: this.color, */
           borderRadius: BorderRadius.all(Radius.circular(7))),
       child: this.child,
     );

--- a/app_feup/lib/view/Widgets/schedule_card.dart
+++ b/app_feup/lib/view/Widgets/schedule_card.dart
@@ -20,7 +20,7 @@ class ScheduleCard extends GenericCard {
 
   final double borderRadius = 12.0;
   final double leftPadding = 12.0;
-  final List<Lecture> lectures =  <Lecture>[];
+  final List<Lecture> lectures = <Lecture>[];
 
   @override
   Widget buildCardContent(BuildContext context) {
@@ -37,7 +37,7 @@ class ScheduleCard extends GenericCard {
                   lecturesInfo.item1 != null && lecturesInfo.item1.isNotEmpty,
               onNullContent: Center(
                   child: Text('Não existem aulas para apresentar',
-                      style: Theme.of(context).textTheme.headline4,
+                      style: Theme.of(context).textTheme.headline6,
                       textAlign: TextAlign.center)));
         });
   }
@@ -60,7 +60,7 @@ class ScheduleCard extends GenericCard {
       lectures.add(lecturefirstCycle);
       lectures.add(lecturesecondCycle);
     }
-    final List<Widget> rows =  <Widget>[];
+    final List<Widget> rows = <Widget>[];
 
     final now = DateTime.now();
     var added = 0; // Lectures added to widget

--- a/app_feup/lib/view/Widgets/schedule_event_rectangle.dart
+++ b/app_feup/lib/view/Widgets/schedule_event_rectangle.dart
@@ -26,8 +26,7 @@ class ScheduleEventRectangle extends StatelessWidget {
         style: Theme.of(context)
             .textTheme
             .headline5
-            .apply(color: Theme.of(context).accentColor)
-            .apply(fontWeightDelta: -1));
+            .apply(color: Theme.of(context).accentColor));
 
     return Row(
         children: (reverseOrder

--- a/app_feup/lib/view/Widgets/schedule_event_rectangle.dart
+++ b/app_feup/lib/view/Widgets/schedule_event_rectangle.dart
@@ -21,9 +21,13 @@ class ScheduleEventRectangle extends StatelessWidget {
 
   Widget createTopRectangle(context) {
     final Text typeWidget = Text(this.type != null ? ' (${type}) ' : '',
-        style: Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4));
+        style: Theme.of(context).textTheme.bodyText2);
     final Text subjectWidget = Text(this.subject,
-        style: Theme.of(context).textTheme.headline3.apply(fontSizeDelta: 5));
+        style: Theme.of(context)
+            .textTheme
+            .headline5
+            .apply(color: Theme.of(context).accentColor)
+            .apply(fontWeightDelta: -1));
 
     return Row(
         children: (reverseOrder

--- a/app_feup/lib/view/Widgets/schedule_row.dart
+++ b/app_feup/lib/view/Widgets/schedule_row.dart
@@ -23,20 +23,20 @@ class ScheduleRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final roomsKey = '$subject-$rooms-$begin-$end';
-    return  Center(
-        child:  Container(
+    return Center(
+        child: Container(
       padding: EdgeInsets.only(left: 12.0, bottom: 8.0, right: 12),
       margin: EdgeInsets.only(top: 8.0),
-      child:  Row(
+      child: Row(
         mainAxisSize: MainAxisSize.max,
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         crossAxisAlignment: CrossAxisAlignment.center,
         children: <Widget>[
-           ScheduleTimeInterval(begin: this.begin, end: this.end),
-           ScheduleEventRectangle(subject: this.subject, type: this.type),
-           Container(
+          ScheduleTimeInterval(begin: this.begin, end: this.end),
+          ScheduleEventRectangle(subject: this.subject, type: this.type),
+          Container(
               margin: EdgeInsets.only(top: 12.0, bottom: 12.0),
-              child:  Column(
+              child: Column(
                   key: Key(roomsKey),
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: getScheduleRooms(context)))
@@ -51,17 +51,17 @@ class ScheduleRow extends StatelessWidget {
         Text(
           'sem\nsalas',
           textAlign: TextAlign.right,
-          style: Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
+          style: Theme.of(context).textTheme.bodyText2,
         )
       ];
     }
 
-    final List<Widget> rooms =  [];
+    final List<Widget> rooms = [];
     for (String room in this.rooms) {
       rooms.add(
-         Text(
+        Text(
           room,
-          style: Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
+          style: Theme.of(context).textTheme.bodyText2,
         ),
       );
     }

--- a/app_feup/lib/view/Widgets/schedule_slot.dart
+++ b/app_feup/lib/view/Widgets/schedule_slot.dart
@@ -88,18 +88,14 @@ class ScheduleSlot extends StatelessWidget {
 
   Widget createScheduleSlotTeacherInfo(context) {
     return createTextField(
-        this.teacher,
-        Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
-        TextAlign.center);
+        this.teacher, Theme.of(context).textTheme.subtitle1, TextAlign.center);
   }
 
   Widget createScheduleSlotClass(context) {
     final classText =
         this.classNumber != null ? (' | ' + this.classNumber) : '';
     return createTextField(
-        classText,
-        Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
-        TextAlign.center);
+        classText, Theme.of(context).textTheme.subtitle1, TextAlign.center);
   }
 
   Widget createTextField(text, style, alignment) {

--- a/app_feup/lib/view/Widgets/schedule_slot.dart
+++ b/app_feup/lib/view/Widgets/schedule_slot.dart
@@ -33,7 +33,7 @@ class ScheduleSlot extends StatelessWidget {
   }
 
   Widget createScheduleSlotRow(context) {
-    return  Container(
+    return Container(
         key: Key('schedule-slot-time-${this.begin}-${this.end}'),
         margin: EdgeInsets.only(top: 3.0, bottom: 3.0),
         child: Row(
@@ -45,7 +45,7 @@ class ScheduleSlot extends StatelessWidget {
   }
 
   Widget createScheduleSlotTime(context) {
-    return  Column(
+    return Column(
       key: Key('schedule-slot-time-${this.begin}-${this.end}'),
       children: <Widget>[
         createScheduleTime(this.begin, context),
@@ -55,23 +55,15 @@ class ScheduleSlot extends StatelessWidget {
   }
 
   Widget createScheduleTime(String time, context) => createTextField(
-      time,
-      Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
-      TextAlign.center);
+      time, Theme.of(context).textTheme.bodyText2, TextAlign.center);
 
   List<Widget> createScheduleSlotPrimInfo(context) {
     final subjectTextField = createTextField(
-        this.subject,
-        Theme.of(context).textTheme.headline3.apply(fontSizeDelta: 5),
-        TextAlign.center);
-    final typeClassTextField = createTextField(
-        ' (' + this.typeClass + ')',
-        Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
-        TextAlign.center);
+        this.subject, Theme.of(context).textTheme.headline5, TextAlign.center);
+    final typeClassTextField = createTextField(' (' + this.typeClass + ')',
+        Theme.of(context).textTheme.headline5, TextAlign.center);
     final roomTextField = createTextField(
-        this.rooms,
-        Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -4),
-        TextAlign.right);
+        this.rooms, Theme.of(context).textTheme.headline5, TextAlign.right);
     return [
       createScheduleSlotTime(context),
       Column(

--- a/app_feup/lib/view/Widgets/schedule_time_interval.dart
+++ b/app_feup/lib/view/Widgets/schedule_time_interval.dart
@@ -8,16 +8,12 @@ class ScheduleTimeInterval extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  Column(
+    return Column(
       mainAxisAlignment: MainAxisAlignment.spaceAround,
       mainAxisSize: MainAxisSize.max,
       children: <Widget>[
-        Text(this.begin,
-            style:
-                Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -3)),
-        Text(this.end,
-            style:
-                Theme.of(context).textTheme.headline4.apply(fontSizeDelta: -3)),
+        Text(this.begin, style: Theme.of(context).textTheme.bodyText2),
+        Text(this.end, style: Theme.of(context).textTheme.bodyText2),
       ],
     );
   }

--- a/app_feup/lib/view/Widgets/sliver_app_bar_delegate.dart
+++ b/app_feup/lib/view/Widgets/sliver_app_bar_delegate.dart
@@ -17,7 +17,9 @@ class SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     return Container(
       decoration: const BoxDecoration(
         border: Border(
-          bottom: BorderSide(width: 1.0, color: Colors.grey),
+          bottom: BorderSide(
+            width: 1.0, /* color: Colors.grey */
+          ),
         ),
       ),
       constraints: BoxConstraints(maxHeight: 150.0),

--- a/app_feup/lib/view/Widgets/sliver_app_bar_delegate.dart
+++ b/app_feup/lib/view/Widgets/sliver_app_bar_delegate.dart
@@ -18,7 +18,8 @@ class SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
       decoration: const BoxDecoration(
         border: Border(
           bottom: BorderSide(
-            width: 1.0, /* color: Colors.grey */
+            width: 1.0,
+            color: Colors.grey,
           ),
         ),
       ),

--- a/app_feup/lib/view/Widgets/terms_and_condition_dialog.dart
+++ b/app_feup/lib/view/Widgets/terms_and_condition_dialog.dart
@@ -91,6 +91,6 @@ class TermsAndConditionDialog {
   }
 
   static TextStyle getTextMethod(BuildContext context) {
-    return Theme.of(context).textTheme.headline3.apply(fontSizeDelta: -2);
+    return Theme.of(context).textTheme.headline6;
   }
 }

--- a/app_feup/lib/view/Widgets/title_card.dart
+++ b/app_feup/lib/view/Widgets/title_card.dart
@@ -14,16 +14,13 @@ class TitleCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return  Container(
+    return Container(
       margin: EdgeInsets.fromLTRB(12, 12, 12, 0),
       padding: EdgeInsets.only(top: 3, bottom: 3),
       alignment: Alignment.center,
-      child:  Text(
+      child: Text(
         '${this.weekDay}, ${this.day} de ${this.month}',
-        style: Theme.of(context)
-            .textTheme
-            .headline6
-            .apply(fontSizeDelta: 3, fontWeightDelta: -1),
+        style: Theme.of(context).textTheme.headline6,
       ),
     );
   }

--- a/app_feup/lib/view/Widgets/toast_message.dart
+++ b/app_feup/lib/view/Widgets/toast_message.dart
@@ -9,9 +9,9 @@ class ToastMessage {
       context,
       duration: Toast.LENGTH_LONG,
       gravity: Toast.BOTTOM,
-      backgroundColor: toastColor,
+      // backgroundColor: toastColor,
       backgroundRadius: 16.0,
-      textColor: Colors.white,
+      // textColor: Colors.white,
     );
   }
 }

--- a/app_feup/lib/view/Widgets/toast_message.dart
+++ b/app_feup/lib/view/Widgets/toast_message.dart
@@ -9,9 +9,9 @@ class ToastMessage {
       context,
       duration: Toast.LENGTH_LONG,
       gravity: Toast.BOTTOM,
-      // backgroundColor: toastColor,
+      backgroundColor: toastColor,
       backgroundRadius: 16.0,
-      // textColor: Colors.white,
+      textColor: Colors.white,
     );
   }
 }

--- a/app_feup/lib/view/Widgets/trip_row.dart
+++ b/app_feup/lib/view/Widgets/trip_row.dart
@@ -21,20 +21,14 @@ class TripRow extends StatelessWidget {
             Text(this.trip.line,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: Theme.of(context)
-                    .textTheme
-                    .headline4
-                    .apply(fontWeightDelta: 2)),
+                style: Theme.of(context).textTheme.subtitle1),
             Text(this.trip.destination,
-                style: Theme.of(context).textTheme.headline4),
+                style: Theme.of(context).textTheme.subtitle1),
           ],
         ),
         Column(crossAxisAlignment: CrossAxisAlignment.end, children: <Widget>[
           Text(this.trip.timeRemaining.toString() + '\'',
-              style: Theme.of(context)
-                  .textTheme
-                  .headline4
-                  .apply(fontWeightDelta: 2)),
+              style: Theme.of(context).textTheme.subtitle1),
           EstimatedArrivalTimeStamp(
               timeRemaining: this.trip.timeRemaining.toString()),
         ])

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -64,73 +64,38 @@ ThemeData applicationLightTheme = ThemeData(
   ),
 );
 
-/*
 ThemeData applicationDarkTheme = ThemeData(
-    brightness: Brightness.dark,
-    primaryColor: _strongGrey,
-    accentColor: Colors.white,
-    dividerColor: _lightGrey,
-    hintColor: _lightGrey,
-    backgroundColor: _mildBlack,
-    scaffoldBackgroundColor: _mildBlack,
-    textTheme: TextTheme(
-      headline1: TextStyle(
-          fontSize: 72.0, fontWeight: FontWeight.bold, color: Colors.white),
-      headline2: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w300),
-      headline3: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w300),
-      headline4: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w300),
-      headline5: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w400),
-      headline6: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w300),
-      subtitle1: TextStyle(
-          fontSize: 17.0, color: Colors.white, fontWeight: FontWeight.w300),
-      subtitle2: TextStyle(
-          fontSize: 16.0, color: Colors.white, fontWeight: FontWeight.w300),
-      bodyText1: TextStyle(fontSize: 16.0, color: Colors.white),
-      bodyText2: TextStyle(fontSize: 15.0, color: Colors.white),
-      caption: TextStyle(
-          fontSize: 12.0, color: Colors.white, fontWeight: FontWeight.w500),
-    ),
-    iconTheme: IconThemeData(color: Colors.white),
-    unselectedWidgetColor: _grey,
-    toggleableActiveColor: Colors.white,
-    tabBarTheme: TabBarTheme(
-      unselectedLabelColor: Colors.white,
-      labelColor: Colors.white,
-      labelPadding: EdgeInsets.all(0.0),
-    ),
-    canvasColor: _mildBlack,
-    cardColor: Colors.white,
-    elevatedButtonTheme: ElevatedButtonThemeData(
-      style: ElevatedButton.styleFrom(
-          primary: Colors.black45,
-          padding: const EdgeInsets.all(10.0),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12.0),
-          ),
-          textStyle: TextStyle(
-              color: Colors.black,
-              fontWeight: FontWeight.w400,
-              fontSize: 15.0)),
-    ),
-    textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-            primary: Colors.white,
-            textStyle: TextStyle(fontSize: 15.0, fontWeight: FontWeight.w400))),
-    checkboxTheme: CheckboxThemeData(
-        checkColor: MaterialStateProperty.all(Colors.white),
-        fillColor: MaterialStateColor.resolveWith(
-          (states) {
-            if (states.contains(MaterialState.selected)) {
-              return _darkRed; // the color when checkbox is selected;
-            }
-            return _grey; //the color when checkbox is unselected;
-          },
-        ))); */
-
-ThemeData applicationDarkTheme =
-    applicationLightTheme.copyWith(brightness: Brightness.dark);
+  brightness: Brightness.dark,
+  hintColor: _grey,
+  primaryColor: Colors.white,
+  accentColor: Colors.white,
+  backgroundColor: _mildBlack,
+  scaffoldBackgroundColor: _mildBlack,
+  textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+          primary: Colors.white,
+          textStyle: TextStyle(fontSize: 15.0, fontWeight: FontWeight.w400))),
+  textTheme: TextTheme(
+    headline1: TextStyle(fontSize: 40.0, fontWeight: FontWeight.w400),
+    headline2: TextStyle(fontSize: 32.0, fontWeight: FontWeight.w400),
+    headline3: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w400),
+    headline4: TextStyle(
+        fontSize: 24.0, fontWeight: FontWeight.w300, color: Colors.white),
+    headline5: TextStyle(
+        fontSize: 20.0, fontWeight: FontWeight.w400, color: Colors.white),
+    headline6: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
+    subtitle1: TextStyle(
+        fontSize: 17.0, fontWeight: FontWeight.w300, color: Colors.white),
+    subtitle2: TextStyle(
+        fontSize: 16.0, fontWeight: FontWeight.w300, color: Colors.white),
+    bodyText1: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w400),
+    bodyText2: TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400),
+    caption: TextStyle(fontSize: 13.0, fontWeight: FontWeight.w400),
+  ),
+  tabBarTheme: TabBarTheme(
+    unselectedLabelColor: Colors.white,
+    labelColor: Colors.white,
+    labelPadding: EdgeInsets.all(0.0),
+  ),
+  checkboxTheme: applicationLightTheme.checkboxTheme,
+);

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:math';
 
 const Color _darkRed = Color.fromARGB(255, 0x75, 0x17, 0x1e);
 const Color _lightRed = Color.fromARGB(255, 190, 40, 40);
@@ -8,7 +9,74 @@ const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
 const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
 const Color _mildBlack = Color.fromARGB(255, 0x30, 0x30, 0x30);
 
+MaterialColor generateMaterialColor(Color color) {
+  return MaterialColor(color.value, {
+    50: tintColor(color, 0.9),
+    100: tintColor(color, 0.8),
+    200: tintColor(color, 0.6),
+    300: tintColor(color, 0.4),
+    400: tintColor(color, 0.2),
+    500: color,
+    600: shadeColor(color, 0.1),
+    700: shadeColor(color, 0.2),
+    800: shadeColor(color, 0.3),
+    900: shadeColor(color, 0.4),
+  });
+}
+
+int tintValue(int value, double factor) =>
+    max(0, min((value + ((255 - value) * factor)).round(), 255));
+
+Color tintColor(Color color, double factor) => Color.fromRGBO(
+    tintValue(color.red, factor),
+    tintValue(color.green, factor),
+    tintValue(color.blue, factor),
+    1);
+
+int shadeValue(int value, double factor) =>
+    max(0, min(value - (value * factor).round(), 255));
+
+Color shadeColor(Color color, double factor) => Color.fromRGBO(
+    shadeValue(color.red, factor),
+    shadeValue(color.green, factor),
+    shadeValue(color.blue, factor),
+    1);
+
 ThemeData applicationLightTheme = ThemeData(
+  brightness: Brightness.light,
+  primarySwatch: generateMaterialColor(_darkRed),
+  /* primaryColor: _darkRed, */
+  textTheme: TextTheme(
+    headline1: TextStyle(
+      fontSize: 72.0,
+      fontWeight: FontWeight.bold, /* color: _darkRed */
+    ),
+    headline2: TextStyle(
+        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w300),
+    headline3: TextStyle(
+        fontSize: 17.0, /* color: _lightRed, */ fontWeight: FontWeight.w300),
+    headline4: TextStyle(
+        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w300),
+    headline5: TextStyle(
+        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w400),
+    headline6: TextStyle(
+        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w300),
+    subtitle1: TextStyle(
+        fontSize: 17.0, /* color: _grey, */ fontWeight: FontWeight.w300),
+    subtitle2: TextStyle(
+        fontSize: 16.0, /* color: _grey, */ fontWeight: FontWeight.w300),
+    bodyText1: TextStyle(
+      fontSize: 16.0, /* color: _mildBlack */
+    ),
+    bodyText2: TextStyle(
+      fontSize: 15.0, /* color: _mildBlack */
+    ),
+    caption: TextStyle(
+        fontSize: 12.0, /* color: _grey, */ fontWeight: FontWeight.w500),
+  ),
+);
+/* 
+ThemeData applicationLightTheme_ = ThemeData(
     brightness: Brightness.light,
     primaryColor: Colors.white,
     accentColor: _darkRed,
@@ -71,7 +139,8 @@ ThemeData applicationLightTheme = ThemeData(
             return _grey; //the color when checkbox is unselected;
           },
         )));
-
+ */
+/* 
 ThemeData applicationDarkTheme = ThemeData(
     brightness: Brightness.dark,
     primaryColor: _strongGrey,
@@ -137,7 +206,7 @@ ThemeData applicationDarkTheme = ThemeData(
             }
             return _grey; //the color when checkbox is unselected;
           },
-        )));
+        ))); */
 
-ThemeData applicationPureDarkTheme =
-    applicationDarkTheme.copyWith(scaffoldBackgroundColor: Colors.black);
+ThemeData applicationDarkTheme =
+    applicationLightTheme.copyWith(brightness: Brightness.dark);

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'dart:math';
 
 const Color _darkRed = Color.fromARGB(255, 0x75, 0x17, 0x1e);
 const Color _lightRed = Color.fromARGB(255, 190, 40, 40);
@@ -9,31 +8,13 @@ const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
 const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
 const Color _mildBlack = Color.fromARGB(255, 0x30, 0x30, 0x30);
 
-int _tintValue(int value, double factor) =>
-    max(0, min((value + ((255 - value) * factor)).round(), 255));
-
-Color tintColor(Color color, double factor) => Color.fromRGBO(
-    _tintValue(color.red, factor),
-    _tintValue(color.green, factor),
-    _tintValue(color.blue, factor),
-    1);
-
-int _shadeValue(int value, double factor) =>
-    max(0, min(value - (value * factor).round(), 255));
-
-Color shadeColor(Color color, double factor) => Color.fromRGBO(
-    _shadeValue(color.red, factor),
-    _shadeValue(color.green, factor),
-    _shadeValue(color.blue, factor),
-    1);
-
 ThemeData applicationLightTheme = ThemeData(
   brightness: Brightness.light,
   primaryColor: _darkRed,
   accentColor: _lightRed,
   backgroundColor: _mildWhite,
   scaffoldBackgroundColor: _mildWhite,
-  hintColor: Colors.white,
+  hintColor: _lightGrey,
   dividerColor: _lightGrey,
   tabBarTheme: TabBarTheme(
     unselectedLabelColor: _strongGrey,
@@ -66,84 +47,24 @@ ThemeData applicationLightTheme = ThemeData(
       )),
   textTheme: TextTheme(
     headline1: TextStyle(fontSize: 72.0, fontWeight: FontWeight.w400),
-    headline2: TextStyle(fontSize: 50.0, fontWeight: FontWeight.w300),
-    headline3: TextStyle(fontSize: 42.0, fontWeight: FontWeight.w300),
-    headline4: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w300),
-    headline5: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w300),
+    headline2: TextStyle(fontSize: 50.0, fontWeight: FontWeight.w400),
+    headline3: TextStyle(fontSize: 40.0, fontWeight: FontWeight.w400),
+    headline4: TextStyle(
+        fontSize: 26.0, fontWeight: FontWeight.w300, color: _mildBlack),
+    headline5: TextStyle(
+        fontSize: 20.0, fontWeight: FontWeight.w400, color: _strongGrey),
     headline6: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
-    subtitle1: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
-    subtitle2: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w300),
+    subtitle1: TextStyle(
+        fontSize: 17.0, fontWeight: FontWeight.w300, color: _strongGrey),
+    subtitle2: TextStyle(
+        fontSize: 16.0, fontWeight: FontWeight.w300, color: _strongGrey),
     bodyText1: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w400),
     bodyText2: TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400),
     caption: TextStyle(fontSize: 13.0, fontWeight: FontWeight.w400),
   ),
 );
-/* 
-ThemeData applicationLightTheme_ = ThemeData(
-    brightness: Brightness.light,
-    primaryColor: Colors.white,
-    accentColor: _darkRed,
-    dividerColor: _lightGrey,
-    hintColor: _lightGrey,
-    backgroundColor: _mildWhite,
-    scaffoldBackgroundColor: _mildWhite,
-    textTheme: TextTheme(
-      headline1: TextStyle(
-          fontSize: 72.0, fontWeight: FontWeight.bold, color: _darkRed),
-      headline2: TextStyle(
-          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-      headline3: TextStyle(
-          fontSize: 17.0, color: _lightRed, fontWeight: FontWeight.w300),
-      headline4: TextStyle(
-          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-      headline5: TextStyle(
-          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w400),
-      headline6: TextStyle(
-          fontSize: 17.0, color: _mildBlack, fontWeight: FontWeight.w300),
-      subtitle1:
-          TextStyle(fontSize: 17.0, color: _grey, fontWeight: FontWeight.w300),
-      subtitle2:
-          TextStyle(fontSize: 16.0, color: _grey, fontWeight: FontWeight.w300),
-      bodyText1: TextStyle(fontSize: 16.0, color: _mildBlack),
-      bodyText2: TextStyle(fontSize: 15.0, color: _mildBlack),
-      caption:
-          TextStyle(fontSize: 12.0, color: _grey, fontWeight: FontWeight.w500),
-    ),
-    iconTheme: IconThemeData(color: _strongGrey),
-    unselectedWidgetColor: _grey,
-    toggleableActiveColor: _darkRed,
-    tabBarTheme: TabBarTheme(
-      unselectedLabelColor: _strongGrey,
-      labelColor: _strongGrey,
-      labelPadding: EdgeInsets.all(0.0),
-    ),
-    canvasColor: _mildWhite,
-    cardColor: Colors.white,
-    elevatedButtonTheme: ElevatedButtonThemeData(
-      style: ElevatedButton.styleFrom(
-          primary: _darkRed,
-          padding: const EdgeInsets.all(10.0),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(12.0),
-          ),
-          textStyle: TextStyle(fontWeight: FontWeight.w400, fontSize: 15.0)),
-    ),
-    textButtonTheme: TextButtonThemeData(
-        style: TextButton.styleFrom(
-            primary: _darkRed,
-            textStyle: TextStyle(fontSize: 15.0, fontWeight: FontWeight.w400))),
-    checkboxTheme: CheckboxThemeData(
-        checkColor: MaterialStateProperty.all(Colors.white),
-        fillColor: MaterialStateColor.resolveWith(
-          (states) {
-            if (states.contains(MaterialState.selected)) {
-              return _darkRed; // the color when checkbox is selected;
-            }
-            return _grey; //the color when checkbox is unselected;
-          },
-        )));
- */
-/* 
+
+/*
 ThemeData applicationDarkTheme = ThemeData(
     brightness: Brightness.dark,
     primaryColor: _strongGrey,

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -5,6 +5,7 @@ const Color _lightRed = Color.fromARGB(255, 190, 40, 40);
 const Color _white = Color.fromARGB(255, 232, 232, 232);
 const Color _mildWhite = Color.fromARGB(255, 0xfa, 0xfa, 0xfa);
 const Color _lightGrey = Color.fromARGB(255, 215, 215, 215);
+const Color _mildGrey = Color.fromARGB(255, 180, 180, 180);
 const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
 const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
 const Color _mildBlack = Color.fromARGB(255, 0x30, 0x30, 0x30);
@@ -81,7 +82,7 @@ ThemeData applicationDarkTheme = ThemeData(
   cardColor: Color.fromARGB(255, 43, 43, 43),
   textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
-          primary: Colors.white,
+          primary: _white,
           textStyle: TextStyle(fontSize: 15.0, fontWeight: FontWeight.w400))),
   textTheme: TextTheme(
     headline1: TextStyle(fontSize: 40.0, fontWeight: FontWeight.w400),
@@ -89,22 +90,22 @@ ThemeData applicationDarkTheme = ThemeData(
     headline3: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w400),
     headline4: TextStyle(
         fontSize: 24.0, fontWeight: FontWeight.w300, color: Colors.white),
-    headline5:
-        TextStyle(fontSize: 20.0, fontWeight: FontWeight.w400, color: _grey),
+    headline5: TextStyle(
+        fontSize: 20.0, fontWeight: FontWeight.w400, color: _mildGrey),
     headline6: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
     subtitle1: TextStyle(
         fontSize: 17.0, fontWeight: FontWeight.w300, color: _lightGrey),
-    subtitle2:
-        TextStyle(fontSize: 16.0, fontWeight: FontWeight.w300, color: _grey),
+    subtitle2: TextStyle(
+        fontSize: 16.0, fontWeight: FontWeight.w300, color: _mildGrey),
     bodyText1: TextStyle(
         fontSize: 16.0, fontWeight: FontWeight.w400, color: _lightGrey),
-    bodyText2:
-        TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400, color: _grey),
+    bodyText2: TextStyle(
+        fontSize: 14.0, fontWeight: FontWeight.w400, color: _mildGrey),
     caption: TextStyle(fontSize: 13.0, fontWeight: FontWeight.w400),
   ),
   tabBarTheme: TabBarTheme(
-    unselectedLabelColor: Colors.white,
-    labelColor: Colors.white,
+    unselectedLabelColor: _white,
+    labelColor: _white,
     labelPadding: EdgeInsets.all(0.0),
   ),
   checkboxTheme: applicationLightTheme.checkboxTheme,

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -9,70 +9,73 @@ const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
 const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
 const Color _mildBlack = Color.fromARGB(255, 0x30, 0x30, 0x30);
 
-MaterialColor generateMaterialColor(Color color) {
-  return MaterialColor(color.value, {
-    50: tintColor(color, 0.9),
-    100: tintColor(color, 0.8),
-    200: tintColor(color, 0.6),
-    300: tintColor(color, 0.4),
-    400: tintColor(color, 0.2),
-    500: color,
-    600: shadeColor(color, 0.1),
-    700: shadeColor(color, 0.2),
-    800: shadeColor(color, 0.3),
-    900: shadeColor(color, 0.4),
-  });
-}
-
-int tintValue(int value, double factor) =>
+int _tintValue(int value, double factor) =>
     max(0, min((value + ((255 - value) * factor)).round(), 255));
 
 Color tintColor(Color color, double factor) => Color.fromRGBO(
-    tintValue(color.red, factor),
-    tintValue(color.green, factor),
-    tintValue(color.blue, factor),
+    _tintValue(color.red, factor),
+    _tintValue(color.green, factor),
+    _tintValue(color.blue, factor),
     1);
 
-int shadeValue(int value, double factor) =>
+int _shadeValue(int value, double factor) =>
     max(0, min(value - (value * factor).round(), 255));
 
 Color shadeColor(Color color, double factor) => Color.fromRGBO(
-    shadeValue(color.red, factor),
-    shadeValue(color.green, factor),
-    shadeValue(color.blue, factor),
+    _shadeValue(color.red, factor),
+    _shadeValue(color.green, factor),
+    _shadeValue(color.blue, factor),
     1);
 
 ThemeData applicationLightTheme = ThemeData(
   brightness: Brightness.light,
-  primarySwatch: generateMaterialColor(_darkRed),
-  /* primaryColor: _darkRed, */
+  primaryColor: _darkRed,
+  accentColor: _lightRed,
+  backgroundColor: _mildWhite,
+  scaffoldBackgroundColor: _mildWhite,
+  hintColor: Colors.white,
+  dividerColor: _lightGrey,
+  tabBarTheme: TabBarTheme(
+    unselectedLabelColor: _strongGrey,
+    labelColor: _strongGrey,
+    labelPadding: EdgeInsets.all(0.0),
+    indicator: ShapeDecoration(
+        shape: UnderlineInputBorder(
+            borderSide: BorderSide(width: 4.0, color: _darkRed))),
+  ),
+  elevatedButtonTheme: ElevatedButtonThemeData(
+    style: ElevatedButton.styleFrom(
+        primary: _darkRed,
+        padding: const EdgeInsets.all(10.0),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(12.0),
+        ),
+        textStyle: TextStyle(fontWeight: FontWeight.w400, fontSize: 15.0)),
+  ),
+  iconTheme: IconThemeData(color: _darkRed),
+  textButtonTheme: TextButtonThemeData(
+      style: TextButton.styleFrom(
+          primary: _darkRed,
+          textStyle: TextStyle(fontSize: 15.0, fontWeight: FontWeight.w400))),
+  checkboxTheme: CheckboxThemeData(
+      checkColor: MaterialStateProperty.all(Colors.white),
+      fillColor: MaterialStateColor.resolveWith(
+        (states) {
+          return states.contains(MaterialState.selected) ? _darkRed : _grey;
+        },
+      )),
   textTheme: TextTheme(
-    headline1: TextStyle(
-      fontSize: 72.0,
-      fontWeight: FontWeight.bold, /* color: _darkRed */
-    ),
-    headline2: TextStyle(
-        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w300),
-    headline3: TextStyle(
-        fontSize: 17.0, /* color: _lightRed, */ fontWeight: FontWeight.w300),
-    headline4: TextStyle(
-        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w300),
-    headline5: TextStyle(
-        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w400),
-    headline6: TextStyle(
-        fontSize: 17.0, /* color: _mildBlack, */ fontWeight: FontWeight.w300),
-    subtitle1: TextStyle(
-        fontSize: 17.0, /* color: _grey, */ fontWeight: FontWeight.w300),
-    subtitle2: TextStyle(
-        fontSize: 16.0, /* color: _grey, */ fontWeight: FontWeight.w300),
-    bodyText1: TextStyle(
-      fontSize: 16.0, /* color: _mildBlack */
-    ),
-    bodyText2: TextStyle(
-      fontSize: 15.0, /* color: _mildBlack */
-    ),
-    caption: TextStyle(
-        fontSize: 12.0, /* color: _grey, */ fontWeight: FontWeight.w500),
+    headline1: TextStyle(fontSize: 72.0, fontWeight: FontWeight.w400),
+    headline2: TextStyle(fontSize: 50.0, fontWeight: FontWeight.w300),
+    headline3: TextStyle(fontSize: 42.0, fontWeight: FontWeight.w300),
+    headline4: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w300),
+    headline5: TextStyle(fontSize: 20.0, fontWeight: FontWeight.w300),
+    headline6: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
+    subtitle1: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
+    subtitle2: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w300),
+    bodyText1: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w400),
+    bodyText2: TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400),
+    caption: TextStyle(fontSize: 13.0, fontWeight: FontWeight.w400),
   ),
 );
 /* 

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -2,20 +2,24 @@ import 'package:flutter/material.dart';
 
 const Color _darkRed = Color.fromARGB(255, 0x75, 0x17, 0x1e);
 const Color _lightRed = Color.fromARGB(255, 190, 40, 40);
+const Color _white = Color.fromARGB(255, 232, 232, 232);
 const Color _mildWhite = Color.fromARGB(255, 0xfa, 0xfa, 0xfa);
 const Color _lightGrey = Color.fromARGB(255, 215, 215, 215);
 const Color _grey = Color.fromARGB(255, 0x7f, 0x7f, 0x7f);
 const Color _strongGrey = Color.fromARGB(255, 90, 90, 90);
 const Color _mildBlack = Color.fromARGB(255, 0x30, 0x30, 0x30);
+const Color _darkBlack = Color.fromARGB(255, 27, 27, 27);
 
 ThemeData applicationLightTheme = ThemeData(
   brightness: Brightness.light,
   primaryColor: _darkRed,
   accentColor: _lightRed,
+  canvasColor: _mildWhite,
   backgroundColor: _mildWhite,
   scaffoldBackgroundColor: _mildWhite,
   hintColor: _lightGrey,
   dividerColor: _lightGrey,
+  cardColor: Color.fromARGB(255, 0xff, 0xff, 0xff),
   tabBarTheme: TabBarTheme(
     unselectedLabelColor: _strongGrey,
     labelColor: _strongGrey,
@@ -34,6 +38,7 @@ ThemeData applicationLightTheme = ThemeData(
         textStyle: TextStyle(fontWeight: FontWeight.w400, fontSize: 15.0)),
   ),
   iconTheme: IconThemeData(color: _darkRed),
+  accentIconTheme: IconThemeData(color: _darkRed),
   textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
           primary: _darkRed,
@@ -66,11 +71,14 @@ ThemeData applicationLightTheme = ThemeData(
 
 ThemeData applicationDarkTheme = ThemeData(
   brightness: Brightness.dark,
-  hintColor: _grey,
-  primaryColor: Colors.white,
-  accentColor: Colors.white,
-  backgroundColor: _mildBlack,
-  scaffoldBackgroundColor: _mildBlack,
+  hintColor: Color.fromARGB(255, 43, 43, 43),
+  dividerColor: Color.fromARGB(255, 100, 100, 100),
+  primaryColor: _white,
+  accentColor: _white,
+  canvasColor: _darkBlack,
+  backgroundColor: _darkBlack,
+  scaffoldBackgroundColor: _darkBlack,
+  cardColor: Color.fromARGB(255, 43, 43, 43),
   textButtonTheme: TextButtonThemeData(
       style: TextButton.styleFrom(
           primary: Colors.white,
@@ -81,15 +89,17 @@ ThemeData applicationDarkTheme = ThemeData(
     headline3: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w400),
     headline4: TextStyle(
         fontSize: 24.0, fontWeight: FontWeight.w300, color: Colors.white),
-    headline5: TextStyle(
-        fontSize: 20.0, fontWeight: FontWeight.w400, color: Colors.white),
+    headline5:
+        TextStyle(fontSize: 20.0, fontWeight: FontWeight.w400, color: _grey),
     headline6: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),
     subtitle1: TextStyle(
-        fontSize: 17.0, fontWeight: FontWeight.w300, color: Colors.white),
-    subtitle2: TextStyle(
-        fontSize: 16.0, fontWeight: FontWeight.w300, color: Colors.white),
-    bodyText1: TextStyle(fontSize: 16.0, fontWeight: FontWeight.w400),
-    bodyText2: TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400),
+        fontSize: 17.0, fontWeight: FontWeight.w300, color: _lightGrey),
+    subtitle2:
+        TextStyle(fontSize: 16.0, fontWeight: FontWeight.w300, color: _grey),
+    bodyText1: TextStyle(
+        fontSize: 16.0, fontWeight: FontWeight.w400, color: _lightGrey),
+    bodyText2:
+        TextStyle(fontSize: 14.0, fontWeight: FontWeight.w400, color: _grey),
     caption: TextStyle(fontSize: 13.0, fontWeight: FontWeight.w400),
   ),
   tabBarTheme: TabBarTheme(
@@ -98,4 +108,7 @@ ThemeData applicationDarkTheme = ThemeData(
     labelPadding: EdgeInsets.all(0.0),
   ),
   checkboxTheme: applicationLightTheme.checkboxTheme,
+  elevatedButtonTheme: applicationLightTheme.elevatedButtonTheme,
+  iconTheme: IconThemeData(color: _white),
+  accentIconTheme: IconThemeData(color: _white),
 );

--- a/app_feup/lib/view/theme.dart
+++ b/app_feup/lib/view/theme.dart
@@ -46,11 +46,11 @@ ThemeData applicationLightTheme = ThemeData(
         },
       )),
   textTheme: TextTheme(
-    headline1: TextStyle(fontSize: 72.0, fontWeight: FontWeight.w400),
-    headline2: TextStyle(fontSize: 50.0, fontWeight: FontWeight.w400),
-    headline3: TextStyle(fontSize: 40.0, fontWeight: FontWeight.w400),
+    headline1: TextStyle(fontSize: 40.0, fontWeight: FontWeight.w400),
+    headline2: TextStyle(fontSize: 32.0, fontWeight: FontWeight.w400),
+    headline3: TextStyle(fontSize: 28.0, fontWeight: FontWeight.w400),
     headline4: TextStyle(
-        fontSize: 26.0, fontWeight: FontWeight.w300, color: _mildBlack),
+        fontSize: 24.0, fontWeight: FontWeight.w300, color: _mildBlack),
     headline5: TextStyle(
         fontSize: 20.0, fontWeight: FontWeight.w400, color: _strongGrey),
     headline6: TextStyle(fontSize: 18.0, fontWeight: FontWeight.w300),

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -8,7 +8,7 @@ description: A FEUP no teu bolso
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
 
-version: 1.1.1+27
+version: 1.1.1+28
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
Closes #398.
Refactors theme properties across the app to fit with Google Material Design guidelines. No major visual design changes should be noticeable.
The dark theme is to be injected with the new color palette after this gets merged to the respective branch. 

# Review checklist
- [ ] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [ ] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [ ] Clean, well structured code
