### PR TITLE
Feature/improve ux on editing mode

### DIFF
--- a/app_feup/lib/view/Widgets/generic_card.dart
+++ b/app_feup/lib/view/Widgets/generic_card.dart
@@ -48,7 +48,7 @@ class GenericCardState extends State<GenericCard> {
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
-        onTap: () => widget.onClick(context),
+        onTap: () => !widget.editingMode && widget.onClick(context),
         child: Card(
             margin: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
             color: Color.fromARGB(0, 0, 0, 0),

--- a/app_feup/lib/view/Widgets/main_cards_list.dart
+++ b/app_feup/lib/view/Widgets/main_cards_list.dart
@@ -99,13 +99,19 @@ class MainCardsList extends StatelessWidget {
         builder: (context, favoriteWidgets) {
           return Container(
               height: MediaQuery.of(context).size.height,
-              child: ReorderableListView(
+              child: isEditing(context) ? ReorderableListView(
                 onReorder: (oldi, newi) =>
                     this.reorderCard(oldi, newi, favoriteWidgets, context),
                 header: this.createTopBar(context),
                 children: this
                     .createFavoriteWidgetsFromTypes(favoriteWidgets, context),
                 //Cards go here
+              ) : ListView(
+                children: <Widget>[
+                  this.createTopBar(context),
+                  ...this
+                      .createFavoriteWidgetsFromTypes(favoriteWidgets, context)
+                ],
               ));
         });
   }

--- a/app_feup/pubspec.yaml
+++ b/app_feup/pubspec.yaml
@@ -8,7 +8,7 @@ description: A FEUP no teu bolso
 # build by specifying --build-name and --build-number, respectively.
 # Read more about versioning at semver.org.
 
-version: 1.1.1+35
+version: 1.1.1+36
 
 
 environment:

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Android's `targetSdkVersion` to 30
 - Changed the Checkbox background to dark red
 - Changed 'Paragens' to 'Autocarros'
+- Limited widget dragging to within editing mode
 
 ## [1.1.0] - 2021-04-18
 


### PR DESCRIPTION
Closes #456 
Allows users to drag cards only while in editing mode and disables clicking on widgets during editing.

# Review checklist
- [x] Terms and conditions reflect the current change
- [ ] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [x] Behavior is as expected
- [x] Clean, well structured code
