### PR TITLE
Feature/refactor weekdays

### DIFF
--- a/uni/lib/model/entities/lecture.dart
+++ b/uni/lib/model/entities/lecture.dart
@@ -1,16 +1,8 @@
 import 'package:logger/logger.dart';
+import 'package:uni/model/entities/time_utilities.dart';
 
 /// Stores information about a lecture.
 class Lecture {
-  static var dayName = [
-    'Segunda-feira',
-    'Terça-feira',
-    'Quarta-feira',
-    'Quinta-feira',
-    'Sexta-feira',
-    'Sábado',
-    'Domingo'
-  ];
   String subject;
   String startTime;
   String endTime;
@@ -143,7 +135,7 @@ class Lecture {
   /// Prints the data in this lecture to the [Logger] with an INFO level.
   printLecture() {
     Logger().i('$subject $typeClass');
-    Logger().i('${dayName[day]} $startTime $endTime $blocks blocos');
+    Logger().i('${TimeString.weekdays[day]} $startTime $endTime $blocks blocos');
     Logger().i('$room  $teacher\n');
   }
 

--- a/uni/lib/model/entities/lecture.dart
+++ b/uni/lib/model/entities/lecture.dart
@@ -135,7 +135,7 @@ class Lecture {
   /// Prints the data in this lecture to the [Logger] with an INFO level.
   printLecture() {
     Logger().i('$subject $typeClass');
-    Logger().i('${TimeString.weekdays[day]} $startTime $endTime $blocks blocos');
+    Logger().i('${TimeString.getWeekdaysStrings()[day]} $startTime $endTime $blocks blocos');
     Logger().i('$room  $teacher\n');
   }
 

--- a/uni/lib/model/entities/time_utilities.dart
+++ b/uni/lib/model/entities/time_utilities.dart
@@ -2,4 +2,14 @@ extension TimeString on DateTime {
   String toTimeHourMinString() {
     return '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
   }
+
+  static const weekdays = [
+    'Segunda-Feira',
+    'Terça-Feira',
+    'Quarta-Feira',
+    'Quinta-Feira',
+    'Sexta-Feira',
+    'Sábado',
+    'Domingo'
+  ];
 }

--- a/uni/lib/model/entities/time_utilities.dart
+++ b/uni/lib/model/entities/time_utilities.dart
@@ -3,13 +3,22 @@ extension TimeString on DateTime {
     return '${hour.toString().padLeft(2, '0')}:${minute.toString().padLeft(2, '0')}';
   }
 
-  static const weekdays = [
-    'Segunda-Feira',
-    'Terça-Feira',
-    'Quarta-Feira',
-    'Quinta-Feira',
-    'Sexta-Feira',
-    'Sábado',
-    'Domingo'
-  ];
+  static List<String> getWeekdaysStrings({bool startMonday = true, bool includeWeekend = true}) {
+    final List<String> weekdays = [
+      'Segunda-Feira',
+      'Terça-Feira',
+      'Quarta-Feira',
+      'Quinta-Feira',
+      'Sexta-Feira',
+      'Sábado',
+      'Domingo'
+    ];
+
+    if (!startMonday) {
+      weekdays.removeAt(6);
+      weekdays.insert(0, 'Domingo');
+    }
+
+    return includeWeekend ? weekdays : weekdays.sublist(0, 5);
+  }
 }

--- a/uni/lib/view/home/widgets/schedule_card.dart
+++ b/uni/lib/view/home/widgets/schedule_card.dart
@@ -78,7 +78,7 @@ class ScheduleCard extends GenericCard {
       if (stringTimeNow.compareTo(stringEndTimeLecture) < 0) {
         if (now.weekday - 1 != lectures[i].day &&
             lastDayAdded < lectures[i].day) {
-          rows.add(DateRectangle(date: Lecture.dayName[lectures[i].day % 7]));
+          rows.add(DateRectangle(date: TimeString.weekdays[lectures[i].day % 7]));
         }
 
         rows.add(createRowFromLecture(context, lectures[i]));
@@ -88,7 +88,7 @@ class ScheduleCard extends GenericCard {
     }
 
     if (rows.isEmpty) {
-      rows.add(DateRectangle(date: Lecture.dayName[lectures[0].day % 7]));
+      rows.add(DateRectangle(date: TimeString.weekdays[lectures[0].day % 7]));
       rows.add(createRowFromLecture(context, lectures[0]));
     }
     return rows;

--- a/uni/lib/view/home/widgets/schedule_card.dart
+++ b/uni/lib/view/home/widgets/schedule_card.dart
@@ -78,7 +78,7 @@ class ScheduleCard extends GenericCard {
       if (stringTimeNow.compareTo(stringEndTimeLecture) < 0) {
         if (now.weekday - 1 != lectures[i].day &&
             lastDayAdded < lectures[i].day) {
-          rows.add(DateRectangle(date: TimeString.weekdays[lectures[i].day % 7]));
+          rows.add(DateRectangle(date: TimeString.getWeekdaysStrings()[lectures[i].day % 7]));
         }
 
         rows.add(createRowFromLecture(context, lectures[i]));
@@ -88,7 +88,7 @@ class ScheduleCard extends GenericCard {
     }
 
     if (rows.isEmpty) {
-      rows.add(DateRectangle(date: TimeString.weekdays[lectures[0].day % 7]));
+      rows.add(DateRectangle(date: TimeString.getWeekdaysStrings()[lectures[0].day % 7]));
       rows.add(createRowFromLecture(context, lectures[0]));
     }
     return rows;

--- a/uni/lib/view/schedule/schedule.dart
+++ b/uni/lib/view/schedule/schedule.dart
@@ -3,12 +3,12 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:tuple/tuple.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/lecture.dart';
+import 'package:uni/model/entities/time_utilities.dart';
 import 'package:uni/view/common_widgets/page_title.dart';
 import 'package:uni/view/common_widgets/request_dependent_widget_builder.dart';
 import 'package:uni/view/schedule/widgets/schedule_slot.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
 import 'package:uni/utils/drawer_items.dart';
-
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({Key? key}) : super(key: key);
@@ -46,13 +46,7 @@ class SchedulePageView extends StatefulWidget {
 
   final int weekDay = DateTime.now().weekday;
 
-  static final List<String> daysOfTheWeek = [
-    'Segunda-feira',
-    'Terça-feira',
-    'Quarta-feira',
-    'Quinta-feira',
-    'Sexta-feira'
-  ];
+  static final List<String> daysOfTheWeek = TimeString.weekdays.sublist(0, 5);
 
   static List<List<Lecture>> groupLecturesByDay(schedule) {
     final aggLectures = <List<Lecture>>[];
@@ -73,7 +67,7 @@ class SchedulePageView extends StatefulWidget {
 
 class SchedulePageViewState extends GeneralPageViewState<SchedulePageView>
     with TickerProviderStateMixin {
-   TabController? tabController;
+  TabController? tabController;
 
   @override
   void initState() {

--- a/uni/lib/view/schedule/schedule.dart
+++ b/uni/lib/view/schedule/schedule.dart
@@ -46,7 +46,8 @@ class SchedulePageView extends StatefulWidget {
 
   final int weekDay = DateTime.now().weekday;
 
-  static final List<String> daysOfTheWeek = TimeString.weekdays.sublist(0, 5);
+  static final List<String> daysOfTheWeek =
+      TimeString.getWeekdaysStrings(includeWeekend: false);
 
   static List<List<Lecture>> groupLecturesByDay(schedule) {
     final aggLectures = <List<Lecture>>[];


### PR DESCRIPTION
Closes #458 
Replaced the weekdays' lists being used for the lectures with the one in [app_feup/lib/model/entities/time_utilities.dart](https://github.com/NIAEFEUP/project-schrodinger/blob/feature/refactor-weekdays/app_feup/lib/model/entities/time_utilities.dart#L4). However by doing this, weekdays now appear simplified ('Segunda' instead of 'Segunda-feira'):

![image](https://user-images.githubusercontent.com/75942759/158085290-7f756765-571b-4609-8b90-1a676157138e.png)
![image](https://user-images.githubusercontent.com/75942759/158085311-8ab993bd-69fa-4a1e-b28d-c2a3bb97fa3e.png)

Depends on #430 (that's where the weekdays' list is implemented).


# Review checklist
- [x] Terms and conditions reflect the current change
- [x] Contains enough appropriate tests
- [ ] Increments version in `pubspec.yaml` (changes `1.0.0+1` to `1.0.0+2` for example)
- [ ] Properly adds entry in `changelog.md` with the change
- [x] If PR includes UI updates/additions, its description has screenshots
- [ ] Behavior is as expected
- [x] Clean, well structured code
