### PR TITLE
Fix canLaunchUrl()

### DIFF
--- a/uni/android/app/src/main/AndroidManifest.xml
+++ b/uni/android/app/src/main/AndroidManifest.xml
@@ -31,6 +31,26 @@
             android:name="flutterEmbedding"
             android:value="2" />
     </application>
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="http" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="tel" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="mailto" />
+        </intent>
+    </queries>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_CALENDAR"/>
     <uses-permission android:name="android.permission.READ_CALENDAR"/>

--- a/uni/ios/Runner/Info.plist
+++ b/uni/ios/Runner/Info.plist
@@ -41,6 +41,13 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>http</string>
+		<string>https</string>
+		<string>tel</string>
+		<string>mailto</string>
+	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>


### PR DESCRIPTION
The canLaunchUrl function was returning false in cases that aren't supposed. This happened because of an update of newer android versions.
To fixed it I added some <intend> tags to the <queries> at AndroidManifest.xml. And it works!
For IOS I also done the equivalent thing but didn't test.

[Android info](https://pub.dev/packages/url_launcher#android)
[IOS info](https://pub.dev/packages/url_launcher#ios)

@franciscopana This fix the canLaunchUrl function, can you check if this also close the #519?
