### PR TITLE
Feature/faculty selection name preview

### DIFF
--- a/uni/lib/view/Pages/login_page_view.dart
+++ b/uni/lib/view/Pages/login_page_view.dart
@@ -38,7 +38,7 @@ class LoginPageViewState extends State<LoginPageView> {
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   static bool _exitApp = false;
-  bool _keepSignedIn = false;
+  bool _keepSignedIn = true;
   bool _obscurePasswordInput = true;
 
   void _login(BuildContext context) {

--- a/uni/lib/view/Widgets/faculties_multiselect.dart
+++ b/uni/lib/view/Widgets/faculties_multiselect.dart
@@ -54,8 +54,7 @@ class FacultiesMultiselect extends StatelessWidget {
     if (selectedFaculties.isEmpty) {
       return 'sem faculdade';
     }
-    String facultiesText =
-        selectedFaculties.length == 1 ? 'faculdade: ' : 'faculdades: ';
+    String facultiesText = '';
     for (String faculty in selectedFaculties) {
       facultiesText += '${faculty.toUpperCase()}, ';
     }

--- a/uni/lib/view/Widgets/faculties_multiselect.dart
+++ b/uni/lib/view/Widgets/faculties_multiselect.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:uni/view/Widgets/faculties_selection_form.dart';
 
 class FacultiesMultiselect extends StatelessWidget {
-  final List<String> faculties;
+  final List<String> selectedFaculties;
   final Function setFaculties;
 
-  const FacultiesMultiselect(this.faculties, this.setFaculties, {super.key});
+  const FacultiesMultiselect(this.selectedFaculties, this.setFaculties,
+      {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -20,13 +21,13 @@ class FacultiesMultiselect extends StatelessWidget {
               context: context,
               builder: (BuildContext context) {
                 return FacultiesSelectionForm(
-                    List<String>.from(faculties), setFaculties);
+                    List<String>.from(selectedFaculties), setFaculties);
               });
         },
-        child: createButtonContent(context));
+        child: _createButtonContent(context));
   }
 
-  Widget createButtonContent(BuildContext context) {
+  Widget _createButtonContent(BuildContext context) {
     return Container(
         padding: const EdgeInsets.fromLTRB(5, 0, 5, 7),
         decoration: const BoxDecoration(
@@ -35,16 +36,29 @@ class FacultiesMultiselect extends StatelessWidget {
           color: Colors.white,
           width: 1,
         ))),
-        child: Row(children: const [
-          Text(
-            'a(s) tua(s) faculdade(s)',
-            style: TextStyle(color: Colors.white),
+        child: Row(children: [
+          Expanded(
+            child: Text(
+              _facultiesListText(),
+              style: const TextStyle(color: Colors.white),
+            ),
           ),
-          Spacer(),
-          Icon(
+          const Icon(
             Icons.arrow_drop_down,
             color: Colors.white,
           ),
         ]));
+  }
+
+  String _facultiesListText() {
+    if (selectedFaculties.isEmpty) {
+      return 'sem faculdade';
+    }
+    String facultiesText =
+        selectedFaculties.length == 1 ? 'faculdade: ' : 'faculdades: ';
+    for (String faculty in selectedFaculties) {
+      facultiesText += '${faculty.toUpperCase()}, ';
+    }
+    return facultiesText.substring(0, facultiesText.length - 2);
   }
 }

--- a/uni/lib/view/Widgets/faculties_selection_form.dart
+++ b/uni/lib/view/Widgets/faculties_selection_form.dart
@@ -2,10 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:uni/utils/constants.dart' as constants;
 
 class FacultiesSelectionForm extends StatefulWidget {
-  final List<String> faculties;
+  final List<String> selectedFaculties;
   final Function setFaculties;
 
-  const FacultiesSelectionForm(this.faculties, this.setFaculties, {super.key});
+  const FacultiesSelectionForm(this.selectedFaculties, this.setFaculties,
+      {super.key});
 
   @override
   State<StatefulWidget> createState() => _FacultiesSelectionFormState();
@@ -34,7 +35,7 @@ class _FacultiesSelectionFormState extends State<FacultiesSelectionForm> {
               onPrimary: Theme.of(context).primaryColor, primary: Colors.white),
           onPressed: () {
             Navigator.pop(context);
-            widget.setFaculties(widget.faculties);
+            widget.setFaculties(widget.selectedFaculties);
           },
           child: const Text('Confirmar'))
     ];
@@ -48,13 +49,13 @@ class _FacultiesSelectionFormState extends State<FacultiesSelectionForm> {
           title: Text(faculty.toUpperCase(),
               style: const TextStyle(color: Colors.white, fontSize: 20.0)),
           key: Key('FacultyCheck$faculty'),
-          value: widget.faculties.contains(faculty),
+          value: widget.selectedFaculties.contains(faculty),
           onChanged: (value) {
             setState(() {
               if (value != null && value) {
-                widget.faculties.add(faculty);
+                widget.selectedFaculties.add(faculty);
               } else {
-                widget.faculties.remove(faculty);
+                widget.selectedFaculties.remove(faculty);
               }
             });
           });

--- a/uni/lib/view/Widgets/faculties_selection_form.dart
+++ b/uni/lib/view/Widgets/faculties_selection_form.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:uni/utils/constants.dart' as constants;
+import 'package:uni/view/Widgets/toast_message.dart';
 
 class FacultiesSelectionForm extends StatefulWidget {
   final List<String> selectedFaculties;
@@ -34,6 +35,11 @@ class _FacultiesSelectionFormState extends State<FacultiesSelectionForm> {
           style: ElevatedButton.styleFrom(
               onPrimary: Theme.of(context).primaryColor, primary: Colors.white),
           onPressed: () {
+            if (widget.selectedFaculties.isEmpty) {
+              ToastMessage.display(
+                  context, 'Seleciona pelo menos uma faculdade');
+              return;
+            }
             Navigator.pop(context);
             widget.setFaculties(widget.selectedFaculties);
           },

--- a/uni/lib/view/Widgets/toast_message.dart
+++ b/uni/lib/view/Widgets/toast_message.dart
@@ -6,7 +6,7 @@ class ToastMessage {
   static display(BuildContext context, String msg) {
     ToastContext().init(context);
     Toast.show(msg,
-        duration: Toast.lengthShort,
+        duration: Toast.lengthLong,
         gravity: Toast.bottom,
         backgroundColor: toastColor,
         backgroundRadius: 16.0);


### PR DESCRIPTION
Closes #535 
Shows preview on selected faculties on the login screen and prevents zero faculties from being selected in the selection modal.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
