### PR TITLE
Fix/profile pic first load

### DIFF
--- a/uni/lib/controller/load_info.dart
+++ b/uni/lib/controller/load_info.dart
@@ -124,5 +124,6 @@ Future<File?> loadProfilePicture(Store<AppState> store) {
       'https://sigarra.up.pt/$faculty/pt/fotografias_service.foto?pct_cod=$studentNumber';
   final Map<String, String> headers = <String, String>{};
   headers['cookie'] = store.state.content['session'].cookies;
-  return loadImageFromCacheOrGetAndCache('profile_pic.png', url, headers);
+  return loadImageFromStorageOrRetrieveNew(
+      'user_profile_picture', url, headers);
 }

--- a/uni/lib/controller/load_info.dart
+++ b/uni/lib/controller/load_info.dart
@@ -116,12 +116,14 @@ Future<void> handleRefresh(store) {
   return action.completer.future;
 }
 
-Future<File?> loadProfilePicture(Store<AppState> store) {
+Future<File?> loadProfilePicture(Store<AppState> store,
+    {forceRetrieval = false}) {
   final String studentNumber = store.state.content['session'].studentNumber;
   final String faculty = store.state.content['session'].faculties[0];
   final String url =
       'https://sigarra.up.pt/$faculty/pt/fotografias_service.foto?pct_cod=$studentNumber';
   final Map<String, String> headers = <String, String>{};
   headers['cookie'] = store.state.content['session'].cookies;
-  return loadFileFromStorageOrRetrieveNew('user_profile_picture', url, headers);
+  return loadFileFromStorageOrRetrieveNew('user_profile_picture', url, headers,
+      forceRetrieval: forceRetrieval);
 }

--- a/uni/lib/controller/load_info.dart
+++ b/uni/lib/controller/load_info.dart
@@ -30,7 +30,7 @@ Future loadReloginInfo(Store<AppState> store) async {
 
 Future loadUserInfoToState(store) async {
   loadLocalUserInfoToState(store);
-  if (await (Connectivity().checkConnectivity()) != ConnectionState.none) {
+  if (await Connectivity().checkConnectivity() != ConnectivityResult.none) {
     return loadRemoteUserInfoToState(store);
   }
 }

--- a/uni/lib/controller/load_info.dart
+++ b/uni/lib/controller/load_info.dart
@@ -2,11 +2,10 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:redux/redux.dart';
 import 'package:tuple/tuple.dart';
 import 'package:uni/controller/local_storage/app_shared_preferences.dart';
-import 'package:uni/controller/local_storage/image_offline_storage.dart';
+import 'package:uni/controller/local_storage/file_offline_storage.dart';
 import 'package:uni/controller/parsers/parser_exams.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/redux/action_creators.dart';
@@ -124,6 +123,5 @@ Future<File?> loadProfilePicture(Store<AppState> store) {
       'https://sigarra.up.pt/$faculty/pt/fotografias_service.foto?pct_cod=$studentNumber';
   final Map<String, String> headers = <String, String>{};
   headers['cookie'] = store.state.content['session'].cookies;
-  return loadImageFromStorageOrRetrieveNew(
-      'user_profile_picture', url, headers);
+  return loadFileFromStorageOrRetrieveNew('user_profile_picture', url, headers);
 }

--- a/uni/lib/controller/load_info.dart
+++ b/uni/lib/controller/load_info.dart
@@ -117,13 +117,12 @@ Future<void> handleRefresh(store) {
   return action.completer.future;
 }
 
-Future<File?> loadProfilePic(Store<AppState> store) {
-  // TODO: Investigate first load fail (#527)
+Future<File?> loadProfilePicture(Store<AppState> store) {
   final String studentNumber = store.state.content['session'].studentNumber;
   final String faculty = store.state.content['session'].faculties[0];
   final String url =
       'https://sigarra.up.pt/$faculty/pt/fotografias_service.foto?pct_cod=$studentNumber';
   final Map<String, String> headers = <String, String>{};
   headers['cookie'] = store.state.content['session'].cookies;
-  return retrieveImage(url, headers);
+  return loadImageFromCacheOrGetAndCache('profile_pic.png', url, headers);
 }

--- a/uni/lib/controller/load_static/terms_and_conditions.dart
+++ b/uni/lib/controller/load_static/terms_and_conditions.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:crypto/crypto.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:http/http.dart' as http;
 import 'package:logger/logger.dart';

--- a/uni/lib/controller/load_static/terms_and_conditions.dart
+++ b/uni/lib/controller/load_static/terms_and_conditions.dart
@@ -12,7 +12,7 @@ import 'package:uni/controller/local_storage/app_shared_preferences.dart';
 ///
 /// If this operation is unsuccessful, an error message is returned.
 Future<String> readTermsAndConditions() async {
-  if (await (Connectivity().checkConnectivity()) != ConnectionState.none) {
+  if (await Connectivity().checkConnectivity() != ConnectivityResult.none) {
     try {
       const String url =
           'https://raw.githubusercontent.com/NIAEFEUP/project-schrodinger/develop/uni/assets/text/TermsAndConditions.md';

--- a/uni/lib/controller/local_storage/file_offline_storage.dart
+++ b/uni/lib/controller/local_storage/file_offline_storage.dart
@@ -14,7 +14,7 @@ Future<String> get _localPath async {
 
 /// Gets cached image named [localFileName].
 /// If not found or too old, downloads it from [url] with [headers].
-Future<File?> loadImageFromStorageOrRetrieveNew(
+Future<File?> loadFileFromStorageOrRetrieveNew(
     String localFileName, String url, Map<String, String> headers,
     {int staleDays = 7}) async {
   final path = await _localPath;
@@ -32,7 +32,7 @@ Future<File?> loadImageFromStorageOrRetrieveNew(
   }
   if (await Connectivity().checkConnectivity() != ConnectivityResult.none) {
     final File? downloadedFile =
-        await _downloadAndSaveImage(targetPath, url, headers);
+        await _downloadAndSaveFile(targetPath, url, headers);
     if (downloadedFile != null) {
       return downloadedFile;
     }
@@ -41,7 +41,7 @@ Future<File?> loadImageFromStorageOrRetrieveNew(
 }
 
 /// Downloads the image located at [url] and saves it in [filePath].
-Future<File?> _downloadAndSaveImage(
+Future<File?> _downloadAndSaveFile(
     String filePath, String url, Map<String, String> headers) async {
   final response = await http.get(url.toUri(), headers: headers);
   if (response.statusCode == 200) {

--- a/uni/lib/controller/local_storage/file_offline_storage.dart
+++ b/uni/lib/controller/local_storage/file_offline_storage.dart
@@ -16,17 +16,18 @@ Future<String> get _localPath async {
 /// If not found or too old, downloads it from [url] with [headers].
 Future<File?> loadFileFromStorageOrRetrieveNew(
     String localFileName, String url, Map<String, String> headers,
-    {int staleDays = 7}) async {
+    {int staleDays = 7, forceRetrieval = false}) async {
   final path = await _localPath;
   final targetPath = '$path/$localFileName';
   final File file = File(targetPath);
 
   final bool fileExists = file.existsSync();
-  final bool fileIsStale = fileExists &&
-      file
-          .lastModifiedSync()
-          .add(Duration(days: staleDays))
-          .isBefore(DateTime.now());
+  final bool fileIsStale = forceRetrieval ||
+      (fileExists &&
+          file
+              .lastModifiedSync()
+              .add(Duration(days: staleDays))
+              .isBefore(DateTime.now()));
   if (fileExists && !fileIsStale) {
     return file;
   }

--- a/uni/lib/controller/local_storage/image_offline_storage.dart
+++ b/uni/lib/controller/local_storage/image_offline_storage.dart
@@ -37,8 +37,7 @@ Future<File?> loadImageFromStorageOrRetrieveNew(
   return null;
 }
 
-/// Downloads the image located at [url] and saves it in [filePath], if it is old enough;
-/// otherwise, the cached version will be returned.
+/// Downloads the image located at [url] and saves it in [filePath].
 Future<File?> _downloadAndSaveImage(
     String filePath, String url, Map<String, String> headers) async {
   final response = await http.get(url.toUri(), headers: headers);

--- a/uni/lib/controller/logout.dart
+++ b/uni/lib/controller/logout.dart
@@ -31,7 +31,7 @@ Future logout(BuildContext context) async {
 
   final path = (await getApplicationDocumentsDirectory()).path;
   (File('$path/profile_pic.png')).delete();
-  GeneralPageViewState.decorageImage = null;
+  GeneralPageViewState.profileImageProvider = null;
   PaintingBinding.instance.imageCache.clear();
   DefaultCacheManager().emptyCache();
 }

--- a/uni/lib/controller/logout.dart
+++ b/uni/lib/controller/logout.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_cache_manager/flutter_cache_manager.dart'
-    show DefaultCacheManager;
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uni/controller/local_storage/app_bus_stop_database.dart';
@@ -30,8 +28,7 @@ Future logout(BuildContext context) async {
   AppCourseUnitsDatabase().deleteCourseUnits();
 
   final path = (await getApplicationDocumentsDirectory()).path;
-  (File('$path/profile_pic.png')).delete();
+  Directory(path).deleteSync(recursive: true);
   GeneralPageViewState.profileImageProvider = null;
   PaintingBinding.instance.imageCache.clear();
-  DefaultCacheManager().emptyCache();
 }

--- a/uni/lib/view/Pages/general_page_view.dart
+++ b/uni/lib/view/Pages/general_page_view.dart
@@ -13,7 +13,7 @@ import 'package:uni/view/Widgets/navigation_drawer.dart';
 /// Manages the section inside the user's personal area.
 abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   final double borderMargin = 18.0;
-  static ImageProvider? decorageImage;
+  static ImageProvider? profileImageProvider;
 
   @override
   Widget build(BuildContext context) {
@@ -24,26 +24,25 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
     return Container();
   }
 
+  Future<DecorationImage> buildProfileDecorationImage(context) async {
+    final profilePictureFile =
+        await loadProfilePicture(StoreProvider.of<AppState>(context));
+    return getProfileDecorationImage(profilePictureFile);
+  }
+
   /// Returns the current user image.
   ///
   /// If the image is not found / doesn't exist returns a generic placeholder.
-  DecorationImage getDecorageImage(File? profilePicture) {
-    final fallbackPicture = decorageImage ??
-        const AssetImage('assets/images/profile_placeholder.png');
-    final ImageProvider image =
-        profilePicture == null ? fallbackPicture : FileImage(profilePicture);
+  DecorationImage getProfileDecorationImage(File? profilePicture) {
+    final ImageProvider image = profilePicture == null
+        ? const AssetImage('assets/images/profile_placeholder.png')
+        : FileImage(profilePicture) as ImageProvider;
 
     final result = DecorationImage(fit: BoxFit.cover, image: image);
-    if (profilePicture != null) {
-      decorageImage = image;
+    if (profilePicture != null && profileImageProvider == null) {
+      profileImageProvider = image;
     }
     return result;
-  }
-
-  Future<DecorationImage> buildDecorageImage(context) async {
-    final storedFile =
-        await loadProfilePic(StoreProvider.of<AppState>(context));
-    return getDecorageImage(storedFile);
   }
 
   Widget refreshState(BuildContext context, Widget child) {
@@ -114,7 +113,7 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   // Gets a round shaped button with the photo of the current user.
   Widget getTopRightButton(BuildContext context) {
     return FutureBuilder(
-        future: buildDecorageImage(context),
+        future: buildProfileDecorationImage(context),
         builder: (BuildContext context,
             AsyncSnapshot<DecorationImage> decorationImage) {
           return TextButton(

--- a/uni/lib/view/Pages/general_page_view.dart
+++ b/uni/lib/view/Pages/general_page_view.dart
@@ -24,10 +24,11 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
     return Container();
   }
 
-  Future<DecorationImage> buildProfileDecorationImage(context) async {
+  Future<DecorationImage> buildProfileDecorationImage(context,
+      {forceRetrieval = false}) async {
     final profilePictureFile = await loadProfilePicture(
         StoreProvider.of<AppState>(context),
-        forceRetrieval: profileImageProvider == null);
+        forceRetrieval: forceRetrieval || profileImageProvider == null);
     return getProfileDecorationImage(profilePictureFile);
   }
 
@@ -50,7 +51,10 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   Widget refreshState(BuildContext context, Widget child) {
     return StoreConnector<AppState, Future<void> Function()?>(
       converter: (store) {
-        return () => handleRefresh(store);
+        return () async {
+          await buildProfileDecorationImage(context, forceRetrieval: true);
+          return handleRefresh(store);
+        };
       },
       builder: (context, refresh) {
         return RefreshIndicator(

--- a/uni/lib/view/Pages/general_page_view.dart
+++ b/uni/lib/view/Pages/general_page_view.dart
@@ -25,8 +25,9 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   }
 
   Future<DecorationImage> buildProfileDecorationImage(context) async {
-    final profilePictureFile =
-        await loadProfilePicture(StoreProvider.of<AppState>(context));
+    final profilePictureFile = await loadProfilePicture(
+        StoreProvider.of<AppState>(context),
+        forceRetrieval: profileImageProvider == null);
     return getProfileDecorationImage(profilePictureFile);
   }
 

--- a/uni/lib/view/Pages/general_page_view.dart
+++ b/uni/lib/view/Pages/general_page_view.dart
@@ -52,7 +52,7 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
     return StoreConnector<AppState, Future<void> Function()?>(
       converter: (store) {
         return () async {
-          await buildProfileDecorationImage(context, forceRetrieval: true);
+          await loadProfilePicture(store, forceRetrieval: true);
           return handleRefresh(store);
         };
       },

--- a/uni/lib/view/Pages/general_page_view.dart
+++ b/uni/lib/view/Pages/general_page_view.dart
@@ -34,12 +34,13 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
   ///
   /// If the image is not found / doesn't exist returns a generic placeholder.
   DecorationImage getProfileDecorationImage(File? profilePicture) {
-    final ImageProvider image = profilePicture == null
-        ? const AssetImage('assets/images/profile_placeholder.png')
-        : FileImage(profilePicture) as ImageProvider;
+    final fallbackPicture = profileImageProvider ??
+        const AssetImage('assets/images/profile_placeholder.png');
+    final ImageProvider image =
+        profilePicture == null ? fallbackPicture : FileImage(profilePicture);
 
     final result = DecorationImage(fit: BoxFit.cover, image: image);
-    if (profilePicture != null && profileImageProvider == null) {
+    if (profilePicture != null) {
       profileImageProvider = image;
     }
     return result;

--- a/uni/lib/view/Pages/profile_page_view.dart
+++ b/uni/lib/view/Pages/profile_page_view.dart
@@ -55,7 +55,7 @@ class ProfilePageViewState extends UnnamedPageViewState<ProfilePageView> {
   /// Returns a widget with the user's profile info (Picture, name and email).
   Widget profileInfo(BuildContext context) {
     return StoreConnector<AppState, Future<File?>?>(
-      converter: (store) => loadProfilePic(store),
+      converter: (store) => loadProfilePicture(store),
       builder: (context, profilePicFile) => FutureBuilder(
         future: profilePicFile,
         builder: (BuildContext context, AsyncSnapshot<File?> profilePic) =>
@@ -67,7 +67,7 @@ class ProfilePageViewState extends UnnamedPageViewState<ProfilePageView> {
                 height: 150.0,
                 decoration: BoxDecoration(
                     shape: BoxShape.circle,
-                    image: getDecorageImage(profilePic.data))),
+                    image: getProfileDecorationImage(profilePic.data))),
             const Padding(padding: EdgeInsets.all(8.0)),
             Text(widget.name,
                 textAlign: TextAlign.center,

--- a/uni/pubspec.yaml
+++ b/uni/pubspec.yaml
@@ -63,7 +63,6 @@ dependencies:
   email_validator: ^2.0.1
   currency_text_input_formatter: ^2.1.5
   expansion_tile_card: ^2.0.0
-  flutter_cache_manager: ^3.3.0
   collection: ^1.16.0
   flutter_map: ^1.1.1
   # The following adds the Cupertino Icons font to your application.


### PR DESCRIPTION
Closes #527
Ditches the Cache Manager dependency (which was being used at the same time as the local file system) and relies completely on the local file system, with custom file stale logic to force the user profile picture to reload after 7 days. In our use case though, this rarely happens, since we'll be forcing the picture reload on a page refresh or the app first load into RAM.
The bug linked in the issue came as expected due to a race condition: the app was still reloading stored session information while the page with the picture was already rendered. With the new logic, in this first load, if the download is not authorized, the local file is returned simply.
Also, for some reason the cache was being used only if the user had no internet connection; this uses the local storage always if the file is recent enough.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
