### PR TITLE
Informating users where the reference is located

### DIFF
--- a/uni/lib/view/Widgets/create_print_mb_dialog.dart
+++ b/uni/lib/view/Widgets/create_print_mb_dialog.dart
@@ -29,6 +29,12 @@ Future<void> addMoneyDialog(BuildContext context) async {
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 5, bottom: 10),
+                      child: Text('Os dados da referência gerada aparecerão no Sigarra, conta corrente. \nPerfil > Conta Corrente',
+                        textAlign: TextAlign.start,
+                        style: Theme.of(context).textTheme.subtitle2)
+                    ),
                     Row(children: [
                       IconButton(
                         icon: const Icon(Icons.indeterminate_check_box),


### PR DESCRIPTION
Adds a paragraph to help students to know where the generated mb reference will be displayed.

<img width="299" alt="Captura de ecrã 2022-09-14, às 01 10 13" src="https://user-images.githubusercontent.com/53405284/190031112-75fc6f30-3aad-47ce-a716-e77f2cc3d0c4.png">


# Review checklist
-   [X] Terms and conditions reflect the current change
-   [X] Contains enough appropriate tests
-   [X] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [X] Properly adds entry in `changelog.md` with the change
-   [X] If PR includes UI updates/additions, its description has screenshots
-   [X] Behavior is as expected
-   [X] Clean, well structured code
