### PR TITLE
Hide information visibility according to faculties

### DIFF
--- a/uni/lib/main.dart
+++ b/uni/lib/main.dart
@@ -10,24 +10,25 @@ import 'package:uni/controller/local_storage/app_shared_preferences.dart';
 import 'package:uni/controller/middleware.dart';
 import 'package:uni/controller/on_start_up.dart';
 import 'package:uni/model/app_state.dart';
-import 'package:uni/view/locations/locations.dart';
-import 'package:uni/redux/reducers.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/about/about.dart';
 import 'package:uni/view/bug_report/bug_report.dart';
+import 'package:uni/view/locations/locations.dart';
+import 'package:uni/view/calendar/calendar.dart';
+import 'package:uni/redux/reducers.dart';
 import 'package:uni/view/bus_stop_next_arrivals/bus_stop_next_arrivals.dart';
 import 'package:uni/view/exams/exams.dart';
 import 'package:uni/view/home/home.dart';
-import 'package:uni/view/calendar/calendar.dart';
 import 'package:uni/view/course_units/course_units.dart';
 import 'package:uni/view/logout_route.dart';
 import 'package:uni/view/splash/splash.dart';
-import 'package:uni/view/useful_info/useful_info.dart';
 import 'package:uni/view/schedule/schedule.dart';
 import 'package:uni/view/common_widgets/page_transition.dart';
 import 'package:uni/view/navigation_service.dart';
 import 'package:uni/view/theme.dart';
 import 'package:uni/view/theme_notifier.dart';
+import 'package:uni/utils/drawer_items.dart';
+import 'package:uni/view/useful_info/useful_info.dart';
+
 
 SentryEvent? beforeSend(SentryEvent event) {
   return event.level == SentryLevel.info ? event : null;
@@ -92,44 +93,63 @@ class MyAppState extends State<MyApp> {
               home: const SplashScreen(),
               navigatorKey: NavigationService.navigatorKey,
               onGenerateRoute: (RouteSettings settings) {
-                switch (settings.name) {
-                  case '/${constants.navPersonalArea}':
-                    return PageTransition.makePageTransition(
-                        page: const HomePageView(), settings: settings);
-                  case '/${constants.navSchedule}':
-                    return PageTransition.makePageTransition(
-                        page: const SchedulePage(), settings: settings);
-                  case '/${constants.navExams}':
-                    return PageTransition.makePageTransition(
-                        page: const ExamsPageView(), settings: settings);
-                  case '/${constants.navStops}':
-                    return PageTransition.makePageTransition(
-                        page: const BusStopNextArrivalsPage(),
-                        settings: settings);
-                  case '/${constants.navCourseUnits}':
-                    return PageTransition.makePageTransition(
-                        page: const CourseUnitsPageView(), settings: settings);
-                  case '/${constants.navLocations}':
-                    return PageTransition.makePageTransition(
-                        page: const LocationsPage(), settings: settings);
-                  case '/${constants.navCalendar}':
-                    return PageTransition.makePageTransition(
-                        page: const CalendarPageView(), settings: settings);
-                  case '/${constants.navUsefulInfo}':
-                    return PageTransition.makePageTransition(
-                        page: const UsefulInfoPageView(), settings: settings);
-                  case '/${constants.navAbout}':
-                    return PageTransition.makePageTransition(
-                        page: const AboutPageView(), settings: settings);
-                  case '/${constants.navBugReport}':
-                    return PageTransition.makePageTransition(
-                        page: const BugReportPageView(),
-                        settings: settings,
-                        maintainState: false);
-                  case '/${constants.navLogOut}':
-                    return LogoutRoute.buildLogoutRoute();
-                }
-                return null;
+                final Map<String, Route<dynamic>> transitions = {
+                  '/${DrawerItem.navPersonalArea.title}' : 
+                  PageTransition.makePageTransition(
+                          page: const HomePageView(), 
+                          settings: settings),
+
+                  '/${DrawerItem .navSchedule.title}' :
+                  PageTransition.makePageTransition(
+                          page: const SchedulePage(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navExams.title}' :
+                  PageTransition.makePageTransition(
+                          page: const ExamsPageView(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navStops.title}' :
+                  PageTransition.makePageTransition(
+                          page: const BusStopNextArrivalsPage(),
+                          settings: settings),
+
+                  '/${DrawerItem.navCourseUnits.title}' :
+                  PageTransition.makePageTransition(
+                          page: const CourseUnitsPageView(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navLocations.title}' :
+                  PageTransition.makePageTransition(
+                          page: const LocationsPage(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navCalendar.title}' :
+                  PageTransition.makePageTransition(
+                          page: const CalendarPageView(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navUsefulInfo.title}' :
+                  PageTransition.makePageTransition(
+                          page: const UsefulInfoPageView(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navAbout.title}' :
+                  PageTransition.makePageTransition(
+                          page: const AboutPageView(), 
+                          settings: settings),
+
+                  '/${DrawerItem.navBugReport.title}' :
+                  PageTransition.makePageTransition(
+                          page: const BugReportPageView(), 
+                          settings: settings,
+                          maintainState: false),
+
+                  '/${DrawerItem.navLogOut.title}' :
+                  LogoutRoute.buildLogoutRoute()
+                };
+
+                return transitions[settings.name];
               }),
         ));
   }

--- a/uni/lib/model/app_state.dart
+++ b/uni/lib/model/app_state.dart
@@ -5,7 +5,8 @@ import 'package:uni/model/entities/location_group.dart';
 import 'package:uni/model/entities/restaurant.dart';
 import 'package:uni/model/entities/session.dart';
 import 'package:uni/model/entities/trip.dart';
-import 'package:uni/utils/constants.dart' as constants;
+import 'package:uni/utils/drawer_items.dart';
+
 
 enum RequestStatus { none, busy, failed, successful }
 
@@ -21,7 +22,7 @@ class AppState {
       'scheduleStatus': RequestStatus.none,
       'loginStatus': RequestStatus.none,
       'examsStatus': RequestStatus.none,
-      'selected_page': constants.navPersonalArea,
+      'selected_page': DrawerItem.navPersonalArea.title,
       'session': Session(
           authenticated: false,
           type: '',

--- a/uni/lib/utils/constants.dart
+++ b/uni/lib/utils/constants.dart
@@ -1,16 +1,5 @@
 library constants;
 
-const navPersonalArea = 'Área Pessoal';
-const navSchedule = 'Horário';
-const navExams = 'Exames';
-const navStops = 'Autocarros';
-const navCourseUnits = 'Cadeiras';
-const navLocations = 'Locais';
-const navCalendar = 'Calendário';
-const navAbout = 'Sobre';
-const navBugReport = 'Bugs e Sugestões';
-const navLogOut = 'Terminar sessão';
-const navUsefulInfo = 'Úteis';
 const faculties = [
   'faup',
   'fbaup',

--- a/uni/lib/utils/drawer_items.dart
+++ b/uni/lib/utils/drawer_items.dart
@@ -1,0 +1,26 @@
+enum DrawerItem {
+  navPersonalArea('Área Pessoal'),
+  navSchedule('Horário'),
+  navExams('Exames'),
+  navCourseUnits('Cadeiras'),
+  navStops('Autocarros'),
+  navLocations('Locais', faculties: {'feup'}),
+  navCalendar('Calendário'),
+  navUsefulInfo('Úteis', faculties: {'feup'}),
+  navAbout('Sobre'),
+  navBugReport('Bugs e Sugestões'),
+  navLogOut('Terminar sessão');
+
+  final String title;
+  final Set<String>? faculties;
+
+  const DrawerItem(this.title, {this.faculties});
+
+  bool isVisible(List<String> userFaculties) {
+    if (faculties == null) {
+      return true;
+    } 
+
+    return userFaculties.any((element) => faculties!.contains(element));
+  }
+}

--- a/uni/lib/utils/favorite_widget_type.dart
+++ b/uni/lib/utils/favorite_widget_type.dart
@@ -1,1 +1,19 @@
-enum FavoriteWidgetType { exams, schedule, printBalance, account, busStops }
+enum FavoriteWidgetType { 
+  exams, 
+  schedule, 
+  printBalance(faculties: {"fcup"}), 
+  account, 
+  busStops;
+
+  final Set<String>? faculties;
+
+  const FavoriteWidgetType({this.faculties});
+
+  bool isVisible(List<String> userFaculties) {
+    if (faculties == null) {
+      return true;
+    } 
+
+    return userFaculties.any((element) => faculties!.contains(element));
+  }
+}

--- a/uni/lib/utils/favorite_widget_type.dart
+++ b/uni/lib/utils/favorite_widget_type.dart
@@ -1,12 +1,13 @@
 enum FavoriteWidgetType { 
   exams, 
   schedule, 
-  printBalance(faculties: {"fcup"}), 
+  printBalance, 
   account, 
   busStops;
 
   final Set<String>? faculties;
 
+  // ignore: unused_element
   const FavoriteWidgetType({this.faculties});
 
   bool isVisible(List<String> userFaculties) {

--- a/uni/lib/view/common_widgets/pages_layouts/general/general.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/general.dart
@@ -9,6 +9,8 @@ import 'package:uni/model/app_state.dart';
 import 'package:uni/view/profile/profile.dart';
 import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart';
+import 'package:uni/utils/drawer_items.dart';
+
 
 /// Page with a hamburger menu and the user profile picture
 abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
@@ -100,8 +102,8 @@ abstract class GeneralPageViewState<T extends StatefulWidget> extends State<T> {
           child: TextButton(
             onPressed: () {
               final currentRouteName = ModalRoute.of(context)!.settings.name;
-              if (currentRouteName != constants.navPersonalArea) {
-                Navigator.pushNamed(context, '/${constants.navPersonalArea}');
+              if (currentRouteName != DrawerItem.navPersonalArea.title) {
+                Navigator.pushNamed(context, '/${DrawerItem.navPersonalArea.title}');
               }
             },
             child: SvgPicture.asset(

--- a/uni/lib/view/common_widgets/pages_layouts/general/general.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/general.dart
@@ -7,7 +7,6 @@ import 'package:flutter_svg/flutter_svg.dart';
 import 'package:uni/controller/load_info.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/view/profile/profile.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart';
 import 'package:uni/utils/drawer_items.dart';
 

--- a/uni/lib/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart
+++ b/uni/lib/view/common_widgets/pages_layouts/general/widgets/navigation_drawer.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
 import 'package:provider/provider.dart';
-import 'package:uni/utils/constants.dart' as constants;
+import 'package:uni/utils/drawer_items.dart';
 import 'package:uni/view/theme_notifier.dart';
+import 'package:uni/model/entities/session.dart';
+import 'package:uni/model/app_state.dart';
+
 
 class NavigationDrawer extends StatefulWidget {
   final BuildContext parentContext;
@@ -16,30 +20,22 @@ class NavigationDrawer extends StatefulWidget {
 
 class NavigationDrawerState extends State<NavigationDrawer> {
   NavigationDrawerState();
-  Map drawerItems = {};
+  Map<DrawerItem, Function(String)> drawerItems = {};
 
   @override
   void initState() {
     super.initState();
-
-    drawerItems = {
-      constants.navPersonalArea: _onSelectPage,
-      constants.navSchedule: _onSelectPage,
-      constants.navExams: _onSelectPage,
-      constants.navCourseUnits: _onSelectPage,
-      constants.navStops: _onSelectPage,
-      constants.navLocations: _onSelectPage,
-      constants.navCalendar: _onSelectPage,
-      constants.navUsefulInfo: _onSelectPage,
-      constants.navAbout: _onSelectPage,
-      constants.navBugReport: _onSelectPage,
-    };
+    
+    drawerItems = {};
+    for (var element in DrawerItem.values) {
+      drawerItems[element] = _onSelectPage;
+    }
   }
 
   // Callback Functions
   getCurrentRoute() =>
       ModalRoute.of(widget.parentContext)!.settings.name == null
-          ? drawerItems.keys.toList()[0]
+          ? drawerItems.keys.toList()[0].title
           : ModalRoute.of(widget.parentContext)!.settings.name!.substring(1);
 
   _onSelectPage(String key) {
@@ -71,15 +67,16 @@ class NavigationDrawerState extends State<NavigationDrawer> {
   }
 
   Widget createLogoutBtn() {
+    final String logOutText = DrawerItem.navLogOut.title;
     return TextButton(
-      onPressed: () => _onLogOut(constants.navLogOut),
+      onPressed: () => _onLogOut(logOutText),
       style: TextButton.styleFrom(
         elevation: 0,
         padding: const EdgeInsets.symmetric(vertical: 0.0, horizontal: 5.0),
       ),
       child: Container(
         padding: const EdgeInsets.all(15.0),
-        child: Text(constants.navLogOut,
+        child: Text(logOutText,
             style: Theme.of(context)
                 .textTheme
                 .headline6!
@@ -105,13 +102,13 @@ class NavigationDrawerState extends State<NavigationDrawer> {
         icon: getThemeIcon(), onPressed: themeNotifier.setNextTheme);
   }
 
-  Widget createDrawerNavigationOption(String d) {
+  Widget createDrawerNavigationOption(DrawerItem d) {
     return Container(
-        decoration: _getSelectionDecoration(d),
+        decoration: _getSelectionDecoration(d.title),
         child: ListTile(
           title: Container(
             padding: const EdgeInsets.only(bottom: 3.0, left: 20.0),
-            child: Text(d,
+            child: Text(d.title,
                 style: TextStyle(
                     fontSize: 18.0,
                     color: Theme.of(context).primaryColor,
@@ -119,17 +116,21 @@ class NavigationDrawerState extends State<NavigationDrawer> {
           ),
           dense: true,
           contentPadding: const EdgeInsets.all(0.0),
-          selected: d == getCurrentRoute(),
-          onTap: () => drawerItems[d](d),
+          selected: d.title == getCurrentRoute(),
+          onTap: () => drawerItems[d]!(d.title),
         ));
   }
 
   @override
   Widget build(BuildContext context) {
     final List<Widget> drawerOptions = [];
+    final store = StoreProvider.of<AppState>(context);
+    final userSession = store.state.content["session"] as Session;
 
     for (var key in drawerItems.keys) {
-      drawerOptions.add(createDrawerNavigationOption(key));
+      if (key.isVisible(userSession.faculties)) {
+        drawerOptions.add(createDrawerNavigationOption(key));
+      }
     }
 
     return Drawer(

--- a/uni/lib/view/course_units/course_units.dart
+++ b/uni/lib/view/course_units/course_units.dart
@@ -4,11 +4,12 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:tuple/tuple.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/course_unit.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
 import 'package:uni/view/common_widgets/page_title.dart';
 import 'package:uni/view/common_widgets/request_dependent_widget_builder.dart';
 import 'package:uni/view/course_units/widgets/course_unit_card.dart';
+import 'package:uni/utils/drawer_items.dart';
+
 
 
 class CourseUnitsPageView extends StatefulWidget {
@@ -103,7 +104,7 @@ class CourseUnitsPageViewState
     return Row(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        const PageTitle(name: constants.navCourseUnits),
+        PageTitle(name: DrawerItem.navCourseUnits.title),
         const Spacer(),
         DropdownButtonHideUnderline(
             child: DropdownButton<String>(

--- a/uni/lib/view/home/widgets/bus_stop_card.dart
+++ b/uni/lib/view/home/widgets/bus_stop_card.dart
@@ -4,11 +4,12 @@ import 'package:tuple/tuple.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/bus_stop.dart';
 import 'package:uni/model/entities/trip.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/bus_stop_selection/bus_stop_selection.dart';
 import 'package:uni/view/bus_stop_next_arrivals/widgets/bus_stop_row.dart';
 import 'package:uni/view/common_widgets/last_update_timestamp.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
+import 'package:uni/utils/drawer_items.dart';
+
 
 /// Manages the bus stops card displayed on the user's personal area
 class BusStopCard extends GenericCard {
@@ -21,7 +22,7 @@ class BusStopCard extends GenericCard {
 
   @override
   onClick(BuildContext context) =>
-      Navigator.pushNamed(context, '/${constants.navStops}');
+      Navigator.pushNamed(context, '/${DrawerItem.navStops.title}');
 
   @override
   Widget buildCardContent(BuildContext context) {

--- a/uni/lib/view/home/widgets/exam_card.dart
+++ b/uni/lib/view/home/widgets/exam_card.dart
@@ -3,13 +3,14 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:tuple/tuple.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/exam.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/exams/widgets/exam_title.dart';
 import 'package:uni/view/exams/widgets/exam_row.dart';
 import 'package:uni/view/common_widgets/date_rectangle.dart';
 import 'package:uni/view/common_widgets/request_dependent_widget_builder.dart';
 import 'package:uni/view/common_widgets/row_container.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
+import 'package:uni/utils/drawer_items.dart';
+
 
 /// Manages the exam card section inside the personal area.
 class ExamCard extends GenericCard {
@@ -24,7 +25,7 @@ class ExamCard extends GenericCard {
 
   @override
   onClick(BuildContext context) =>
-      Navigator.pushNamed(context, '/${constants.navExams}');
+      Navigator.pushNamed(context, '/${DrawerItem.navExams.title}');
 
   static getExamCardColor(BuildContext context, Exam exam) {
     return exam.isHighlighted()

--- a/uni/lib/view/home/widgets/schedule_card.dart
+++ b/uni/lib/view/home/widgets/schedule_card.dart
@@ -8,7 +8,8 @@ import 'package:uni/view/common_widgets/date_rectangle.dart';
 import 'package:uni/view/common_widgets/request_dependent_widget_builder.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
 import 'package:uni/view/schedule/widgets/schedule_slot.dart';
-import 'package:uni/utils/constants.dart' as constants;
+import 'package:uni/utils/drawer_items.dart';
+
 
 class ScheduleCard extends GenericCard {
   ScheduleCard({Key? key}) : super(key: key);
@@ -108,5 +109,5 @@ class ScheduleCard extends GenericCard {
 
   @override
   onClick(BuildContext context) =>
-      Navigator.pushNamed(context, '/${constants.navSchedule}');
+      Navigator.pushNamed(context, '/${DrawerItem.navSchedule.title}');
 }

--- a/uni/lib/view/login/login.dart
+++ b/uni/lib/view/login/login.dart
@@ -3,10 +3,10 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/redux/action_creators.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/common_widgets/toast_message.dart';
 import 'package:uni/view/theme.dart';
 import 'package:uni/view/login/widgets/inputs.dart';
+import 'package:uni/utils/drawer_items.dart';
 
 class LoginPageView extends StatefulWidget {
   const LoginPageView({super.key});
@@ -187,7 +187,7 @@ class LoginPageViewState extends State<LoginPageView> {
                   .content['session']
                   .authenticated) {
             Navigator.pushReplacementNamed(
-                context, '/${constants.navPersonalArea}');
+                context, '/${DrawerItem.navPersonalArea.title}');
           } else if (status == RequestStatus.failed) {
             ToastMessage.display(context, 'O login falhou');
           }

--- a/uni/lib/view/navigation_service.dart
+++ b/uni/lib/view/navigation_service.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:uni/utils/constants.dart' as constants;
+import 'package:uni/utils/drawer_items.dart';
+
 
 /// Manages the navigation logic
 class NavigationService {
@@ -7,6 +8,6 @@ class NavigationService {
       GlobalKey<NavigatorState>();
   static logout() {
     navigatorKey.currentState!
-        .pushNamedAndRemoveUntil('/${constants.navLogOut}', (_) => false);
+        .pushNamedAndRemoveUntil('/${DrawerItem.navLogOut.title}', (_) => false);
   }
 }

--- a/uni/lib/view/schedule/schedule.dart
+++ b/uni/lib/view/schedule/schedule.dart
@@ -3,11 +3,12 @@ import 'package:flutter_redux/flutter_redux.dart';
 import 'package:tuple/tuple.dart';
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/lecture.dart';
-import 'package:uni/utils/constants.dart' as constants;
 import 'package:uni/view/common_widgets/page_title.dart';
 import 'package:uni/view/common_widgets/request_dependent_widget_builder.dart';
 import 'package:uni/view/schedule/widgets/schedule_slot.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
+import 'package:uni/utils/drawer_items.dart';
+
 
 class SchedulePage extends StatefulWidget {
   const SchedulePage({Key? key}) : super(key: key);
@@ -100,7 +101,7 @@ class SchedulePageViewState extends GeneralPageViewState<SchedulePageView>
         scrollDirection: Axis.vertical,
         shrinkWrap: true,
         children: <Widget>[
-          const PageTitle(name: constants.navSchedule),
+          PageTitle(name: DrawerItem.navSchedule.title),
           TabBar(
             controller: tabController,
             isScrollable: true,


### PR DESCRIPTION

Closes #489 
This refactor hides content that should not be present when visiting the app from a university other than FEUP. 
The changes are not hardcoded so it's easy to make any more changes, simply alter the DrawerItem enum to change the visibility.

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
