### PR TITLE
Change exam filter modal

### DIFF
--- a/uni/lib/model/entities/exam.dart
+++ b/uni/lib/model/entities/exam.dart
@@ -20,9 +20,7 @@ var _types = {
   'Mini-testes': 'MT',
   'Normal': 'EN',
   'Recurso': 'ER',
-  'Especial de Conclusão': 'EC',
-  'Port.Est.Especiais': 'EE',
-  'Exames ao abrigo de estatutos especiais': 'EAE'
+  'Especial de Conclusão': 'EC'
 };
 
 /// Manages a generic Exam.

--- a/uni/lib/view/exams/widgets/exam_filter_menu.dart
+++ b/uni/lib/view/exams/widgets/exam_filter_menu.dart
@@ -32,7 +32,7 @@ class ExamFilterMenuState extends State<ExamFilterMenu> {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      icon: const Icon(Icons.settings),
+      icon: const Icon(Icons.filter_alt),
       onPressed: () {
         showAlertDialog(context);
       },

--- a/uni/test/integration/src/exams_page_test.dart
+++ b/uni/test/integration/src/exams_page_test.dart
@@ -129,14 +129,14 @@ void main() {
       expect(find.byKey(Key(sdisExam.toString())), findsOneWidget);
       expect(find.byKey(Key(sopeExam.toString())), findsOneWidget);
 
-      final filterIcon = find.byIcon(Icons.settings);
+      final filterIcon = find.byIcon(Icons.filter_alt);
       expect(filterIcon, findsOneWidget);
 
       filteredExams['ExamDoesNotExist'] = true;
 
       await tester.pumpAndSettle();
       final IconButton filterButton = find
-          .widgetWithIcon(IconButton, Icons.settings)
+          .widgetWithIcon(IconButton, Icons.filter_alt)
           .evaluate()
           .first
           .widget;


### PR DESCRIPTION
Closes #599

The exam filter modal icon is now a funnel icon. The options "Port.Est.Especiais" and "Exames ao abrigo de estatutos especiais" were removed from the modal.

![Screenshot_20221030_160603](https://user-images.githubusercontent.com/42045371/198889251-9a25f902-4c8c-46a6-b39a-d663fe2370ae.png)
![Screenshot_20221030_160700](https://user-images.githubusercontent.com/42045371/198889277-3ab48d9a-1eec-40d7-9214-d1de92be39e1.png)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
