### PR TITLE
Feature/shimmer

### DIFF
--- a/uni/lib/view/common_widgets/request_dependent_widget_builder.dart
+++ b/uni/lib/view/common_widgets/request_dependent_widget_builder.dart
@@ -17,12 +17,14 @@ class RequestDependentWidgetBuilder extends StatelessWidget {
       required this.contentGenerator,
       required this.content,
       required this.contentChecker,
-      required this.onNullContent})
+      required this.onNullContent,
+      this.contentLoadingWidget = const CircularProgressIndicator()})
       : super(key: key);
 
   final BuildContext context;
   final RequestStatus status;
   final Widget Function(dynamic, BuildContext) contentGenerator;
+  final Widget contentLoadingWidget;
   final dynamic content;
   final bool contentChecker;
   final Widget onNullContent;
@@ -48,7 +50,7 @@ class RequestDependentWidgetBuilder extends StatelessWidget {
             }
             return contentChecker
                 ? contentGenerator(content, context)
-                : const Center(child: CircularProgressIndicator());
+                : Center(child: contentLoadingWidget);
           case RequestStatus.failed:
           default:
             return contentChecker

--- a/uni/lib/view/home/widgets/exam_card.dart
+++ b/uni/lib/view/home/widgets/exam_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:tuple/tuple.dart';
+import 'package:shimmer/shimmer.dart';
+
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/exam.dart';
 import 'package:uni/view/exams/widgets/exam_title.dart';
@@ -60,6 +62,7 @@ class ExamCard extends GenericCard {
           child: Text('Não existem exames para apresentar',
               style: Theme.of(context).textTheme.headline6),
         ),
+        contentLoadingWidget: examLoadingShimmerBuilder(context),
       ),
     );
   }
@@ -142,4 +145,86 @@ class ExamCard extends GenericCard {
       ),
     );
   }
+}
+
+
+
+Widget examLoadingShimmerBuilder(BuildContext context){
+  return Center(
+        child: Shimmer.fromColors(
+          baseColor: Theme.of(context).highlightColor,
+          highlightColor: Theme.of(context).colorScheme.onPrimary,
+          child: Container(
+            padding: const EdgeInsets.only(left: 12.0, bottom: 8.0, right: 12),
+            margin: const EdgeInsets.only(top: 8.0),
+            child: Column(
+              children: [
+                Container(
+                    margin: const EdgeInsets.only(top: 8, bottom: 8),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.max,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: <Widget>[
+                        Column(
+                            mainAxisSize: MainAxisSize.max,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Column(
+                                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                                    mainAxisSize: MainAxisSize.max,
+                                    children: <Widget>[ //timestamp section
+                                      Container(
+                                        height: 15, 
+                                        width: 40, 
+                                        color: Colors.black,
+                                      ),
+                                      const SizedBox(height: 2.5,),
+                                      Container(
+                                        height: 15, 
+                                        width: 40, 
+                                        color: Colors.black,
+                                      ),
+
+                                    ],
+                                  )
+                            ]),
+                        Container(height: 30, width: 100, color: Colors.black,), //UC section
+                        Container(height: 40, width: 40, color: Colors.black,), //Calender add section
+                      ],
+                    )),
+              const SizedBox(height: 10,),
+              Row( //Exam room section
+                mainAxisSize: MainAxisSize.max,
+                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Container(
+                    height: 15, 
+                    width: 40, 
+                    color: Colors.black,
+                  ),
+                  const SizedBox(width: 10,),
+                  Container(
+                    height: 15, 
+                    width: 40, 
+                    color: Colors.black,
+                  ),
+                  const SizedBox(width: 10,),
+                  Container(
+                    height: 15, 
+                    width: 40, 
+                    color: Colors.black,
+                  ),
+                  const SizedBox(width: 10,),
+                                    Container(
+                    height: 15, 
+                    width: 40, 
+                    color: Colors.black,
+                  ),
+                ],
+              )
+              ],
+            ))));
 }

--- a/uni/lib/view/home/widgets/schedule_card.dart
+++ b/uni/lib/view/home/widgets/schedule_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:tuple/tuple.dart';
+import 'package:shimmer/shimmer.dart';
+
 import 'package:uni/model/app_state.dart';
 import 'package:uni/model/entities/lecture.dart';
 import 'package:uni/model/entities/time_utilities.dart';
@@ -30,14 +32,16 @@ class ScheduleCard extends GenericCard {
         builder: (context, lecturesInfo) {
           return RequestDependentWidgetBuilder(
               context: context,
-              status: lecturesInfo.item2,
+              status: lecturesInfo.item2,              
               contentGenerator: generateSchedule,
               content: lecturesInfo.item1,
               contentChecker: lecturesInfo.item1.isNotEmpty,
               onNullContent: Center(
                   child: Text('Não existem aulas para apresentar',
                       style: Theme.of(context).textTheme.headline6,
-                      textAlign: TextAlign.center)));
+                      textAlign: TextAlign.center)),
+              contentLoadingWidget: scheduleLoadingShimmerBuilder(context),
+              );
         });
   }
 
@@ -110,4 +114,63 @@ class ScheduleCard extends GenericCard {
   @override
   onClick(BuildContext context) =>
       Navigator.pushNamed(context, '/${DrawerItem.navSchedule.title}');
+}
+
+
+
+
+Widget scheduleLoadingShimmerBuilder(BuildContext context){
+  return Center(
+        child: Shimmer.fromColors(
+          baseColor: Theme.of(context).highlightColor,
+          highlightColor: Theme.of(context).colorScheme.onPrimary,
+          child: Container(
+            padding: const EdgeInsets.only(left: 12.0, bottom: 8.0, right: 12),
+            margin: const EdgeInsets.only(top: 8.0),
+            child: Container(
+                    margin: const EdgeInsets.only(top: 8, bottom: 8),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.max,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.center,
+                      children: <Widget>[
+                        Column(
+                            mainAxisSize: MainAxisSize.max,
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                              Column(
+                                    mainAxisAlignment: MainAxisAlignment.spaceAround,
+                                    mainAxisSize: MainAxisSize.max,
+                                    children: <Widget>[ //timestamp section
+                                      Container(
+                                        height: 15, 
+                                        width: 40, 
+                                        color: Colors.black,
+                                      ),
+                                      const SizedBox(height: 2.5,),
+                                      Container(
+                                        height: 15, 
+                                        width: 40, 
+                                        color: Colors.black,
+                                      ),
+
+                                    ],
+                                  )
+                            ]),
+                            Column(
+                              mainAxisSize: MainAxisSize.max,
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              crossAxisAlignment: CrossAxisAlignment.center,
+                              children: <Widget>[
+                                Container(height: 25, width: 100, color: Colors.black,), //UC section
+                                const SizedBox(height: 10,),
+                                Container(height: 15, width: 150, color: Colors.black,), //UC section
+
+                              ],
+                            ),
+                            Container(height: 15, width: 40, color: Colors.black,), //Room section
+                          ],
+                          )),
+            )));
 }

--- a/uni/pubspec.yaml
+++ b/uni/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   latlong2: ^0.8.1
   flutter_map_marker_popup: ^3.2.0
   material_design_icons_flutter: ^5.0.6595
+  shimmer: ^2.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Closes #444 
Adds a custom shimmer effect when loading the schedule or the exams on the home page, (not very recurrent, except for very slow internet connections or first time loading).

![poggers_shimmer(1)](https://user-images.githubusercontent.com/24589619/198898265-9cf5b75a-d97f-4568-9351-812eeb9d9ff5.gif)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
