### PR TITLE
Add background workers functionality to the app.

### DIFF
--- a/uni/lib/controller/backgroundWorkers/notifications.dart
+++ b/uni/lib/controller/backgroundWorkers/notifications.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:tuple/tuple.dart';
+import 'package:uni/controller/local_storage/app_shared_preferences.dart';
+import 'package:uni/controller/networking/network_router.dart';
+import 'package:uni/model/entities/session.dart';
+import 'package:workmanager/workmanager.dart';
+
+///
+/// Stores all notifications that will be checked and displayed in the background. 
+/// Add your custom notification here, because it will NOT be added at runtime.
+/// (due to background worker limitations).
+/// 
+Map<Type, Notification Function()> notificationMap = {
+
+};
+
+
+
+
+abstract class Notification{
+
+  Tuple2<String, String> buildNotificationContent(Session session);
+
+  bool checkConditionToDisplay(Session session);
+
+  void displayNotification(Tuple2<String, String> content);
+
+  void displayNotificationIfPossible(Session session) async{
+    if(checkConditionToDisplay(session)){
+      displayNotification(buildNotificationContent(session));
+    }
+  }
+
+
+
+}
+
+class NotificationManager{
+  
+  static Future<void> tryRunAll() async{
+    final userInfo = await AppSharedPreferences.getPersistentUserInfo();
+    final faculties = await AppSharedPreferences.getUserFaculties();
+    
+    final Session session =  await NetworkRouter.login(userInfo.item1, userInfo.item2, faculties, false);
+
+
+    notificationMap.forEach((key, value) 
+      {
+        value().displayNotificationIfPossible(session);
+      });
+
+  }
+
+  static void buildNotificationWorker() async {
+    if(Platform.isAndroid){
+      Workmanager().cancelByUniqueName("notification-manager"); //stop task if it's already running
+      Workmanager().registerPeriodicTask("notification-manager", "notification-worker", 
+        constraints: Constraints(networkType: NetworkType.connected),
+        frequency: const Duration(minutes: 15),
+        //FIXME: using initial delay to make login sequence more consistent
+        //can be fixed by only using buildNotificationWorker when user is logged in
+        initialDelay: const Duration(seconds: 30),
+      );
+
+    } else if (Platform.isIOS){
+      //TODO: run at least once in iOS and let background fetch do the rest after?
+      //need a macbook and a iphone to test this smh
+    } else{
+      throw PlatformException(code: "WorkerManager is only supported in iOS and android...");
+    }
+
+  }
+
+}
+

--- a/uni/lib/main.dart
+++ b/uni/lib/main.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:provider/provider.dart';
 import 'package:redux/redux.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:uni/controller/backgroundWorkers/background_callback.dart';
+import 'package:uni/controller/backgroundWorkers/notifications.dart';
 import 'package:uni/controller/local_storage/app_shared_preferences.dart';
 import 'package:uni/controller/middleware.dart';
 import 'package:uni/controller/on_start_up.dart';
@@ -28,6 +31,7 @@ import 'package:uni/view/theme.dart';
 import 'package:uni/view/theme_notifier.dart';
 import 'package:uni/utils/drawer_items.dart';
 import 'package:uni/view/useful_info/useful_info.dart';
+import 'package:workmanager/workmanager.dart';
 
 
 SentryEvent? beforeSend(SentryEvent event) {
@@ -43,6 +47,13 @@ Future<void> main() async {
 
   OnStartUp.onStart(state);
   WidgetsFlutterBinding.ensureInitialized();
+
+  await Workmanager().initialize(workerStartCallback, 
+    isInDebugMode: !kReleaseMode // run workmanager in debug mode when app is in debug mode
+  );
+
+  NotificationManager.buildNotificationWorker();
+
   final savedTheme = await AppSharedPreferences.getThemeMode();
   await SentryFlutter.init((options) {
     options.dsn =

--- a/uni/pubspec.yaml
+++ b/uni/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   latlong2: ^0.8.1
   flutter_map_marker_popup: ^3.2.0
   material_design_icons_flutter: ^5.0.6595
+  workmanager: ^0.5.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION

Inital work for displaying notifications when even UNI is closed

Add workerCallback (iOS and android support)
Add NotificationManager (android support only for now, because I need a macbook to complete background worker support).


# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
