### PR TITLE
Kill Sigarra auth session

### DIFF
--- a/uni/lib/controller/logout.dart
+++ b/uni/lib/controller/logout.dart
@@ -13,16 +13,12 @@ import 'package:uni/controller/local_storage/app_lectures_database.dart';
 import 'package:uni/controller/local_storage/app_refresh_times_database.dart';
 import 'package:uni/controller/local_storage/app_user_database.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
-import 'package:http/http.dart' as http;
-
-Future killAuthentication() async {
-  final response = await http
-      .get(Uri.parse(' https://sigarra.up.pt/feup/pt/vld_validacao.sair'));
-  return response;
-}
+import 'package:uni/controller/networking/network_router.dart';
+import 'package:uni/controller/local_storage/app_shared_preferences.dart';
 
 Future logout(BuildContext context) async {
   final prefs = await SharedPreferences.getInstance();
+  final faculties = await AppSharedPreferences.getUserFaculties();
   await prefs.clear();
 
   AppLecturesDatabase().deleteLectures();
@@ -33,6 +29,7 @@ Future logout(BuildContext context) async {
   AppLastUserInfoUpdateDatabase().deleteLastUpdate();
   AppBusStopDatabase().deleteBusStops();
   AppCourseUnitsDatabase().deleteCourseUnits();
+  NetworkRouter.killAuthentication(faculties);
 
   final path = (await getApplicationDocumentsDirectory()).path;
   final directory = Directory(path);
@@ -41,5 +38,4 @@ Future logout(BuildContext context) async {
   }
   GeneralPageViewState.profileImageProvider = null;
   PaintingBinding.instance.imageCache.clear();
-  killAuthentication();
 }

--- a/uni/lib/controller/logout.dart
+++ b/uni/lib/controller/logout.dart
@@ -13,6 +13,13 @@ import 'package:uni/controller/local_storage/app_lectures_database.dart';
 import 'package:uni/controller/local_storage/app_refresh_times_database.dart';
 import 'package:uni/controller/local_storage/app_user_database.dart';
 import 'package:uni/view/common_widgets/pages_layouts/general/general.dart';
+import 'package:http/http.dart' as http;
+
+Future killAuthentication() async {
+  final response = await http
+      .get(Uri.parse(' https://sigarra.up.pt/feup/pt/vld_validacao.sair'));
+  return response;
+}
 
 Future logout(BuildContext context) async {
   final prefs = await SharedPreferences.getInstance();
@@ -34,4 +41,5 @@ Future logout(BuildContext context) async {
   }
   GeneralPageViewState.profileImageProvider = null;
   PaintingBinding.instance.imageCache.clear();
+  killAuthentication();
 }

--- a/uni/lib/controller/networking/network_router.dart
+++ b/uni/lib/controller/networking/network_router.dart
@@ -175,4 +175,18 @@ class NetworkRouter {
   static List<String> getBaseUrlsFromSession(Session session) {
     return NetworkRouter.getBaseUrls(session.faculties);
   }
+
+  /// Makes an HTTP request to terminate the session in Sigarra.
+  static Future killAuthentication(List<String> faculties) async {
+    final url =
+    '${NetworkRouter.getBaseUrl(faculties[0])}vld_validacao.sair';
+    final response = await http.
+      get(url.toUri()).timeout(const Duration(seconds: loginRequestTimeout));
+    if (response.statusCode == 200) {
+      Logger().i("Logout Successful");
+    }else{
+      Logger().i("Logout Failed");
+    }
+    return response;
+  }
 }


### PR DESCRIPTION
Closes #624
Kills the Sigarra authentication when user logs out

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
