### PR TITLE
Scrap MB references from Sigarra

### DIFF
--- a/uni/lib/view/profile/widgets/reference_card.dart
+++ b/uni/lib/view/profile/widgets/reference_card.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
 import 'package:uni/model/entities/reference.dart';
 import 'package:uni/view/common_widgets/generic_expansion_card.dart';
-import 'package:uni/view/useful_info/widgets/text_components.dart';
 
 class ReferenceCard extends GenericExpansionCard {
   final Reference reference;
@@ -12,11 +12,11 @@ class ReferenceCard extends GenericExpansionCard {
   @override
   Widget buildCardContent(BuildContext context) {
     return Column(
-      children: <Container>[
-        infoText("Data limite: ${_getLimitDate()}", context),
-        infoText("Entidade: ${reference.entity}", context),
-        infoText("Referência: ${reference.reference}", context),
-        infoText("Montante: ${_getAmount()}", context),
+      children: <Widget>[
+        InfoText(text: "Data limite: ${_getLimitDate()}"),
+        InfoCopyRow(infoName: 'Entidade', info: reference.entity.toString()),
+        InfoCopyRow(infoName: 'Referência', info: reference.reference.toString()),
+        InfoCopyRow(infoName: 'Montante', info: _getAmount()),
       ]
     );
   }
@@ -35,4 +35,48 @@ class ReferenceCard extends GenericExpansionCard {
 
   String _getAmount()
       => NumberFormat.simpleCurrency(locale: 'eu').format(reference.amount);
+}
+
+class InfoText extends StatelessWidget {
+  final String text;
+
+  const InfoText({Key? key, required this.text}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(left: 20.0, top: 4.0, bottom: 4.0),
+      alignment: Alignment.centerLeft,
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.bodyText1
+      ),
+    );
+  }
+}
+
+class InfoCopyRow extends StatelessWidget {
+  final String infoName;
+  final String info;
+
+  const InfoCopyRow({Key? key, required this.infoName, required this.info})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: <Widget>[
+          InfoText(text: "$infoName: $info"),
+          InkWell(
+            splashColor: Theme.of(context).highlightColor,
+            child: const Icon(Icons.content_copy, size: 16),
+            onTap: () => Clipboard.setData(ClipboardData(text: info)),
+          )
+        ]
+      )
+    );
+  }
 }


### PR DESCRIPTION
Closes #460
You can now see your references on the app (located in the 'Conta Corrente' card in the profile page).

![Screenshot_1675715163](https://user-images.githubusercontent.com/42045371/217787392-ce94ea4a-570e-49d1-be30-4fe8f99b70a9.png)
![Screenshot_1675715959](https://user-images.githubusercontent.com/42045371/217787397-64ee6402-339e-4d12-b814-0d85d935f2d1.png)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
