### PR TITLE
Do not hide whole library page when there is no data

### DIFF
--- a/uni/lib/view/library/library.dart
+++ b/uni/lib/view/library/library.dart
@@ -40,15 +40,6 @@ class LibraryPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (occupation == null || occupation?.capacity == 0) {
-      return ListView(scrollDirection: Axis.vertical, children: [
-        Center(
-            heightFactor: 2,
-            child: Text('Não existem dados para apresentar',
-                style: Theme.of(context).textTheme.headline6,
-                textAlign: TextAlign.center))
-      ]);
-    }
     return ListView(
         scrollDirection: Axis.vertical,
         shrinkWrap: true,


### PR DESCRIPTION
Closes #703 

# Screenshot
![Screenshot from 2023-02-12 13-58-49](https://user-images.githubusercontent.com/61701401/218315436-3e1e411f-8713-4d95-bdce-99012e91993b.png)

# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well structured code
