### PR TITLE
Fixed empty max seats for unavailable library data

### DIFF
--- a/uni/lib/controller/parsers/parser_library_occupation.dart
+++ b/uni/lib/controller/parsers/parser_library_occupation.dart
@@ -18,11 +18,15 @@ Future<LibraryOccupation> parseLibraryOccupationFromSheets(
     int floor, max;
     try {
       floor = jsonDecoded["table"]["rows"][i]["c"][0]["v"].toInt();
-      max = jsonDecoded["table"]["rows"][i]["c"][1]["v"].toInt();
-      occupation.addFloor(FloorOccupation(i + 1, floor, max));
     } catch (e) {
-      occupation.addFloor(FloorOccupation(i + 1, 0, 0));
+      floor = 0;
     }
+    try {
+      max = jsonDecoded["table"]["rows"][i]["c"][1]["v"].toInt();
+    } catch (e) {
+      max = 0;
+    }
+    occupation.addFloor(FloorOccupation(i + 1, floor, max));
   }
 
   return occupation;

--- a/uni/lib/view/library/widgets/library_occupation_card.dart
+++ b/uni/lib/view/library/widgets/library_occupation_card.dart
@@ -67,7 +67,7 @@ class LibraryOccupationCard extends GenericCard {
             ],
           ),
           circularStrokeCap: CircularStrokeCap.square,
-          backgroundColor: Theme.of(context).hintColor,
+          backgroundColor: Theme.of(context).dividerColor,
           progressColor: Theme.of(context).colorScheme.secondary,
         ));
   }


### PR DESCRIPTION
Closes #[issue number]

Fixed fetching for empty library occupation. Max occupation will now be presented even if the library is empty. 

Also changed the background color because it did not generate a good contrast in the dark theme.

![image](https://user-images.githubusercontent.com/75942759/218412491-e80dbfaf-33ea-4ecc-9e3e-43624fd1ecf3.png)


# Review checklist
-   [ ] Terms and conditions reflect the current change
-   [ ] Contains enough appropriate tests
-   [ ] If aimed at production, writes a new summary in `whatsnew/whatsnew-pt-PT`
-   [ ] Properly adds an entry in `changelog.md` with the change
-   [ ] If PR includes UI updates/additions, its description has screenshots
-   [ ] Behavior is as expected
-   [ ] Clean, well-structured code
