### PR TITLE
Hide "impressões" card

### DIFF
--- a/uni/lib/view/home/widgets/main_cards_list.dart
+++ b/uni/lib/view/home/widgets/main_cards_list.dart
@@ -23,8 +23,9 @@ class MainCardsList extends StatelessWidget {
         ExamCard.fromEditingInformation(k, em, od),
     FavoriteWidgetType.account: (k, em, od) =>
         AccountInfoCard.fromEditingInformation(k, em, od),
-    FavoriteWidgetType.printBalance: (k, em, od) =>
+   /* FavoriteWidgetType.printBalance: (k, em, od) =>
         PrintInfoCard.fromEditingInformation(k, em, od),
+    */
     FavoriteWidgetType.busStops: (k, em, od) =>
         BusStopCard.fromEditingInformation(k, em, od),
     FavoriteWidgetType.libraryOccupation: (k, em, od) =>

--- a/uni/lib/view/profile/profile.dart
+++ b/uni/lib/view/profile/profile.dart
@@ -92,7 +92,9 @@ class ProfilePageViewState extends SecondaryPageViewState<ProfilePageView> {
       list.add(CourseInfoCard(course: widget.courses[i]));
       list.add(const Padding(padding: EdgeInsets.all(5.0)));
     }
+    /*
     list.add(PrintInfoCard());
+     */
     list.add(const Padding(padding: EdgeInsets.all(5.0)));
     list.add(AccountInfoCard());
     return list;

--- a/uni/lib/view/profile/widgets/print_info_card.dart
+++ b/uni/lib/view/profile/widgets/print_info_card.dart
@@ -4,7 +4,9 @@ import 'package:uni/model/app_state.dart';
 import 'package:uni/view/profile/widgets/create_print_mb_dialog.dart';
 import 'package:uni/view/common_widgets/generic_card.dart';
 
+/*
 class PrintInfoCard extends GenericCard {
+
   PrintInfoCard({Key? key}) : super(key: key);
 
   const PrintInfoCard.fromEditingInformation(
@@ -69,3 +71,4 @@ class PrintInfoCard extends GenericCard {
   @override
   onClick(BuildContext context) {}
 }
+ */


### PR DESCRIPTION
Closes #679 
This issue's purpose is to hide the "impressões" card, that is not working currently. 

